### PR TITLE
Adapt Code for 1.18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,10 +122,10 @@ repositories {
 dependencies {
     minecraft "net.minecraftforge:forge:${forge_version}"
     //runtimeOnly fg.deobf("curse.maven:growthcraft-trapper-${curseforge_growthcraft_trapper}")
-    //runtimeOnly fg.deobf("curse.maven:growthcraft-decorations-${curseforge_growthcraft_deco}")
-    //runtimeOnly fg.deobf("curse.maven:jei-${curseforge_jei}")
-    //runtimeOnly fg.deobf("curse.maven:theoneprobe-${curseforge_theoneprobe}")
-    //runtimeOnly fg.deobf("curse.maven:patchouli-${curseforge_patchouli}")
+    runtimeOnly fg.deobf("curse.maven:growthcraft-decorations-${curseforge_growthcraft_deco}")
+    runtimeOnly fg.deobf("curse.maven:jei-${curseforge_jei}")
+    runtimeOnly fg.deobf("curse.maven:theoneprobe-${curseforge_theoneprobe}")
+    runtimeOnly fg.deobf("curse.maven:patchouli-${curseforge_patchouli}")
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,12 @@ buildscript {
     repositories {
         // These repositories are only for Gradle plugins, put any other repositories in the repository block further below
         maven { url = 'https://maven.minecraftforge.net' }
+       // maven { url = 'https://maven.parchmentmc.org' }
         mavenCentral()
     }
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
+      //  classpath 'org.parchmentmc:librarian:1.+'
     }
 }
 
@@ -16,6 +18,7 @@ plugins {
 }
 
 apply plugin: 'net.minecraftforge.gradle'
+//apply plugin: 'org.parchmentmc.librarian.forgegradle'
 
 version = "${minecraft_version}-${growthcraft_version}"
 group = 'growthcraft'
@@ -118,11 +121,10 @@ repositories {
 
 dependencies {
     minecraft "net.minecraftforge:forge:${forge_version}"
-    runtimeOnly fg.deobf("curse.maven:growthcraft-trapper-${curseforge_growthcraft_trapper}")
-    runtimeOnly fg.deobf("curse.maven:growthcraft-decorations-${curseforge_growthcraft_deco}")
-    runtimeOnly fg.deobf("curse.maven:jei-${curseforge_jei}")
-    runtimeOnly fg.deobf("curse.maven:theoneprobe-${curseforge_theoneprobe}")
-    // TODO: 2023.04.08 - Not available for 1.19.4
+    //runtimeOnly fg.deobf("curse.maven:growthcraft-trapper-${curseforge_growthcraft_trapper}")
+    //runtimeOnly fg.deobf("curse.maven:growthcraft-decorations-${curseforge_growthcraft_deco}")
+    //runtimeOnly fg.deobf("curse.maven:jei-${curseforge_jei}")
+    //runtimeOnly fg.deobf("curse.maven:theoneprobe-${curseforge_theoneprobe}")
     //runtimeOnly fg.deobf("curse.maven:patchouli-${curseforge_patchouli}")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ minecraft_version_short=1.18
 
 # Change these values prompts a Feature release
 # https://files.minecraftforge.net/net/minecraftforge/forge/index_1.19.4.html
-forge_version=1.18.2-40.2.9
+forge_version=1.18.2-40.2.10
 
 #  Mod Compatibility
 # ------------------------------------------------
@@ -23,17 +23,17 @@ forge_version=1.18.2-40.2.9
 # curseforge_MODNAME=CURSE_PROJ_ID:CURSE_FILE_ID
 # ------------------------------------------------
 # Growthcraft Trapper - https://www.curseforge.com/minecraft/mc-mods/growthcraft-trapper/files
-curseforge_growthcraft_trapper=453124:4482720
+curseforge_growthcraft_trapper=453124:4458345
 # ------------------------------------------------
 # Growthcraft Decorations - https://www.curseforge.com/minecraft/mc-mods/growthcraft-decorations/files
-curseforge_growthcraft_deco=454039:4456989
+curseforge_growthcraft_deco=454039:3859414
 # JEI - https://www.curseforge.com/minecraft/mc-mods/jei/files
-curseforge_jei=238222:4536209
+curseforge_jei=238222:4593548
 # ------------------------------------------------
 # TheOneProbe https://www.curseforge.com/minecraft/mc-mods/the-one-probe/files
-curseforge_theoneprobe=245211:4442439
+curseforge_theoneprobe=245211:3965688
 # ------------------------------------------------
 # Patchouli https://www.curseforge.com/minecraft/mc-mods/patchouli/files
 # 2023.04.23 - Not available for 1.19.4
-curseforge_patchouli=306770:4391051
+curseforge_patchouli=306770:3846086
 # ------------------------------------------------

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/growthcraft/apiary/GrowthcraftApiary.java
+++ b/src/main/java/growthcraft/apiary/GrowthcraftApiary.java
@@ -1,13 +1,17 @@
 package growthcraft.apiary;
 
-import growthcraft.apiary.init.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import growthcraft.apiary.init.GrowthcraftApiaryBlockEntities;
+import growthcraft.apiary.init.GrowthcraftApiaryBlocks;
+import growthcraft.apiary.init.GrowthcraftApiaryFluids;
+import growthcraft.apiary.init.GrowthcraftApiaryItems;
+import growthcraft.apiary.init.GrowthcraftApiaryMenus;
 import growthcraft.apiary.init.client.GrowthcraftApiaryBlockRenders;
 import growthcraft.apiary.init.config.GrowthcraftApiaryConfig;
 import growthcraft.apiary.shared.Reference;
-import growthcraft.core.init.GrowthcraftCreativeModeTabs;
-import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.CreativeModeTabEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -15,8 +19,6 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 @Mod(Reference.MODID)
 @Mod.EventBusSubscriber(modid = Reference.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
@@ -28,14 +30,14 @@ public class GrowthcraftApiary {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         modEventBus.addListener(this::setup);
         modEventBus.addListener(this::clientSetupEvent);
-        modEventBus.addListener(this::buildCreativeTabContents);
+        //modEventBus.addListener(this::buildCreativeTabContents);
 
         GrowthcraftApiaryConfig.loadConfig();
 
         GrowthcraftApiaryBlocks.BLOCKS.register(modEventBus);
         GrowthcraftApiaryItems.ITEMS.register(modEventBus);
-        GrowthcraftApiaryFluids.FLUID_TYPES.register(modEventBus);
-        GrowthcraftApiaryFluids.FLUIDS.register(modEventBus);
+        //GrowthcraftApiaryFluids.FLUID_TYPES.register(modEventBus);
+        //GrowthcraftApiaryFluids.FLUIDS.register(modEventBus);
         GrowthcraftApiaryBlockEntities.BLOCK_ENTITIES.register(modEventBus);
         GrowthcraftApiaryMenus.MENUS.register(modEventBus);
 
@@ -53,16 +55,16 @@ public class GrowthcraftApiary {
         //});
     }
 
-    public void buildCreativeTabContents(CreativeModeTabEvent.BuildContents event) {
-        if (event.getTab() == GrowthcraftCreativeModeTabs.GROWTHCRAFT_CREATIVE_TAB) {
-            GrowthcraftApiaryItems.ITEMS.getEntries().forEach(itemRegistryObject -> {
-                if (!GrowthcraftApiaryItems.excludeItemRegistry(itemRegistryObject.getId())) {
-                    event.accept(new ItemStack(itemRegistryObject.get()));
-                }
-            });
-        }
-    }
-
+//    public void buildCreativeTabContents(CreativeModeTabEvent.BuildContents event) {
+//        if (event.getTab() == GrowthcraftCreativeModeTabs.GROWTHCRAFT_CREATIVE_TAB) {
+//            GrowthcraftApiaryItems.ITEMS.getEntries().forEach(itemRegistryObject -> {
+//                if (!GrowthcraftApiaryItems.excludeItemRegistry(itemRegistryObject.getId())) {
+//                    event.accept(new ItemStack(itemRegistryObject.get()));
+//                }
+//            });
+//        }
+//    }
+    
     @SubscribeEvent
     public void onServerStarting(ServerStartingEvent event) {
         LOGGER.info("Growthcraft Apiary starting up server-side ...");

--- a/src/main/java/growthcraft/apiary/block/entity/BeeBoxBlockEntity.java
+++ b/src/main/java/growthcraft/apiary/block/entity/BeeBoxBlockEntity.java
@@ -3,7 +3,7 @@ package growthcraft.apiary.block.entity;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
-
+import net.minecraft.network.chat.TranslatableComponent;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.jetbrains.annotations.NotNull;
@@ -76,7 +76,7 @@ public class BeeBoxBlockEntity extends BlockEntity implements BlockEntityTicker<
 
     @Override
     public @NotNull Component getDisplayName() {
-        return Component.translatable("container.growthcraft_apiary.bee_box");
+        return new TranslatableComponent("container.growthcraft_apiary.bee_box");
     }
 
     @Nullable

--- a/src/main/java/growthcraft/apiary/init/GrowthcraftApiaryBlocks.java
+++ b/src/main/java/growthcraft/apiary/init/GrowthcraftApiaryBlocks.java
@@ -64,7 +64,7 @@ public class GrowthcraftApiaryBlocks {
     }
 
     private static Item.Properties getDefaultItemProperties() {
-        Item.Properties properties = new Item.Properties();
+        Item.Properties properties = new Item.Properties().tab(growthcraft.core.shared.Reference.ITEM_GROUP);
         //properties;
         return properties;
     }

--- a/src/main/java/growthcraft/apiary/init/GrowthcraftApiaryMenus.java
+++ b/src/main/java/growthcraft/apiary/init/GrowthcraftApiaryMenus.java
@@ -15,7 +15,7 @@ import net.minecraftforge.registries.RegistryObject;
 public class GrowthcraftApiaryMenus {
 
     public static final DeferredRegister<MenuType<?>> MENUS = DeferredRegister.create(
-            ForgeRegistries.MENU_TYPES, Reference.MODID
+            ForgeRegistries.CONTAINERS, Reference.MODID
     );
 
     public static final RegistryObject<MenuType<BeeBoxMenu>> BEE_BOX_MENU =

--- a/src/main/java/growthcraft/apiary/init/client/GrowthcraftApiaryItemRenders.java
+++ b/src/main/java/growthcraft/apiary/init/client/GrowthcraftApiaryItemRenders.java
@@ -4,7 +4,7 @@ import growthcraft.apiary.init.GrowthcraftApiaryFluids;
 import growthcraft.apiary.shared.Reference;
 import growthcraft.lib.client.ItemRendererUtils;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.client.event.RegisterColorHandlersEvent;
+import net.minecraftforge.client.event.ColorHandlerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -12,7 +12,7 @@ import net.minecraftforge.fml.common.Mod;
 public class GrowthcraftApiaryItemRenders {
 
     @SubscribeEvent
-    public static void registerItemRenders(RegisterColorHandlersEvent.Item event) {
+    public static void registerItemRenders(ColorHandlerEvent.Item event) {
         ItemRendererUtils.registerItem(event, Reference.FluidColor.HONEY.toItemColor(), GrowthcraftApiaryFluids.HONEY.bucket.get());
         ItemRendererUtils.registerItem(event, Reference.FluidColor.HONEY_MEAD.toItemColor(), GrowthcraftApiaryFluids.HONEY_MEAD.bucket.get());
     }

--- a/src/main/java/growthcraft/apples/GrowthcraftApples.java
+++ b/src/main/java/growthcraft/apples/GrowthcraftApples.java
@@ -1,5 +1,8 @@
 package growthcraft.apples;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import growthcraft.apples.init.GrowthcraftApplesBlockEntities;
 import growthcraft.apples.init.GrowthcraftApplesBlocks;
 import growthcraft.apples.init.GrowthcraftApplesFluids;
@@ -7,10 +10,7 @@ import growthcraft.apples.init.GrowthcraftApplesItems;
 import growthcraft.apples.init.client.GrowthcraftApplesBlockRenderers;
 import growthcraft.apples.init.config.GrowthcraftApplesConfig;
 import growthcraft.apples.shared.Reference;
-import growthcraft.core.init.GrowthcraftCreativeModeTabs;
-import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.CreativeModeTabEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -18,8 +18,6 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 @Mod(Reference.MODID)
 @Mod.EventBusSubscriber(modid = Reference.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
@@ -38,8 +36,8 @@ public class GrowthcraftApples {
         // Blocks, Items, Fluids, Block Entities, Containers
         GrowthcraftApplesBlocks.BLOCKS.register(modEventBus);
         GrowthcraftApplesItems.ITEMS.register(modEventBus);
-        GrowthcraftApplesFluids.FLUID_TYPES.register(modEventBus);
-        GrowthcraftApplesFluids.FLUIDS.register(modEventBus);
+        //GrowthcraftApplesFluids.FLUID_TYPES.register(modEventBus);
+        //GrowthcraftApplesFluids.FLUIDS.register(modEventBus);
         GrowthcraftApplesBlockEntities.BLOCK_ENTITIES.register(modEventBus);
 
         MinecraftForge.EVENT_BUS.register(this);

--- a/src/main/java/growthcraft/apples/init/GrowthcraftApplesBlocks.java
+++ b/src/main/java/growthcraft/apples/init/GrowthcraftApplesBlocks.java
@@ -137,7 +137,7 @@ public class GrowthcraftApplesBlocks {
     }
   
     private static Item.Properties getDefaultItemProperties() {
-        Item.Properties properties = new Item.Properties();
+        Item.Properties properties = new Item.Properties().tab(growthcraft.core.shared.Reference.ITEM_GROUP);
         return properties;
     }
 

--- a/src/main/java/growthcraft/apples/init/client/GrowthcraftApplesItemRenders.java
+++ b/src/main/java/growthcraft/apples/init/client/GrowthcraftApplesItemRenders.java
@@ -4,7 +4,7 @@ import growthcraft.apples.init.GrowthcraftApplesFluids;
 import growthcraft.apples.shared.Reference;
 import growthcraft.lib.client.ItemRendererUtils;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.client.event.RegisterColorHandlersEvent;
+import net.minecraftforge.client.event.ColorHandlerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -12,7 +12,7 @@ import net.minecraftforge.fml.common.Mod;
 public class GrowthcraftApplesItemRenders {
 
     @SubscribeEvent
-    public static void registerItemRenders(RegisterColorHandlersEvent.Item event) {
+    public static void registerItemRenders(ColorHandlerEvent.Item event) {
         ItemRendererUtils.registerItem(event, Reference.FluidColor.APPLE_CIDER_FLUID_COLOR.toItemColor(), GrowthcraftApplesFluids.APPLE_CIDER_FLUID.bucket.get());
         ItemRendererUtils.registerItem(event, Reference.FluidColor.APPLE_JUICE_FLUID_COLOR.toItemColor(), GrowthcraftApplesFluids.APPLE_JUICE_FLUID.bucket.get());
     }

--- a/src/main/java/growthcraft/bamboo/GrowthcraftBamboo.java
+++ b/src/main/java/growthcraft/bamboo/GrowthcraftBamboo.java
@@ -1,14 +1,14 @@
 package growthcraft.bamboo;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import growthcraft.bamboo.init.GrowthcraftBambooBlockEntities;
 import growthcraft.bamboo.init.GrowthcraftBambooBlocks;
 import growthcraft.bamboo.init.GrowthcraftBambooItems;
 import growthcraft.bamboo.init.config.GrowthcraftBambooConfig;
 import growthcraft.bamboo.shared.Reference;
-import growthcraft.core.init.GrowthcraftCreativeModeTabs;
-import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.CreativeModeTabEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -16,8 +16,6 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 
 @Mod(Reference.MODID)
@@ -29,7 +27,7 @@ public class GrowthcraftBamboo {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         modEventBus.addListener(this::setup);
         modEventBus.addListener(this::clientSetupEvent);
-        modEventBus.addListener(this::buildCreativeTabContents);
+        //modEventBus.addListener(this::buildCreativeTabContents);
 
         // Config
         GrowthcraftBambooConfig.loadConfig();
@@ -42,15 +40,15 @@ public class GrowthcraftBamboo {
         MinecraftForge.EVENT_BUS.register(this);
     }
 
-    public void buildCreativeTabContents(CreativeModeTabEvent.BuildContents event) {
-        if (event.getTab() == GrowthcraftCreativeModeTabs.GROWTHCRAFT_CREATIVE_TAB) {
-            GrowthcraftBambooItems.ITEMS.getEntries().forEach(itemRegistryObject -> {
-                if (!GrowthcraftBambooItems.excludeItemRegistry(itemRegistryObject.getId())) {
-                    event.accept(new ItemStack(itemRegistryObject.get()));
-                }
-            });
-        }
-    }
+//    public void buildCreativeTabContents(CreativeModeTabEvent.BuildContents event) {
+//        if (event.getTab() == GrowthcraftCreativeModeTabs.GROWTHCRAFT_CREATIVE_TAB) {
+//            GrowthcraftBambooItems.ITEMS.getEntries().forEach(itemRegistryObject -> {
+//                if (!GrowthcraftBambooItems.excludeItemRegistry(itemRegistryObject.getId())) {
+//                    event.accept(new ItemStack(itemRegistryObject.get()));
+//                }
+//            });
+//        }
+//    }
 
     private void clientSetupEvent(final FMLClientSetupEvent event) {
         // Do nothing for now ...

--- a/src/main/java/growthcraft/cellar/GrowthcraftCellar.java
+++ b/src/main/java/growthcraft/cellar/GrowthcraftCellar.java
@@ -1,18 +1,27 @@
 package growthcraft.cellar;
 
-import growthcraft.cellar.init.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import growthcraft.cellar.init.GrowthcraftCellarBlockEntities;
+import growthcraft.cellar.init.GrowthcraftCellarBlocks;
+import growthcraft.cellar.init.GrowthcraftCellarFluids;
+import growthcraft.cellar.init.GrowthcraftCellarItems;
+import growthcraft.cellar.init.GrowthcraftCellarMenus;
+import growthcraft.cellar.init.GrowthcraftCellarRecipes;
 import growthcraft.cellar.init.client.GrowthcraftCellarBlockEntityRenderers;
 import growthcraft.cellar.init.client.GrowthcraftCellarBlockRenderers;
 import growthcraft.cellar.init.config.GrowthcraftCellarConfig;
 import growthcraft.cellar.lib.networking.GrowthcraftCellarMessages;
-import growthcraft.cellar.screen.*;
+import growthcraft.cellar.screen.BrewKettleScreen;
+import growthcraft.cellar.screen.CultureJarScreen;
+import growthcraft.cellar.screen.FermentationBarrelScreen;
+import growthcraft.cellar.screen.FruitPressScreen;
+import growthcraft.cellar.screen.RoasterScreen;
 import growthcraft.cellar.shared.Reference;
-import growthcraft.core.init.GrowthcraftCreativeModeTabs;
 import net.minecraft.client.gui.screens.MenuScreens;
-import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.CreativeModeTabEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -20,8 +29,6 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 
 @Mod(Reference.MODID)
@@ -33,7 +40,7 @@ public class GrowthcraftCellar {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         modEventBus.addListener(this::setup);
         modEventBus.addListener(this::clientSetupEvent);
-        modEventBus.addListener(this::buildCreativeTabContents);
+        //modEventBus.addListener(this::buildCreativeTabContents);
         modEventBus.addListener(this::onRegisterRenderers);
 
         // Config
@@ -43,8 +50,8 @@ public class GrowthcraftCellar {
         GrowthcraftCellarBlocks.BLOCKS.register(modEventBus);
         GrowthcraftCellarItems.ITEMS.register(modEventBus);
         GrowthcraftCellarBlockEntities.BLOCK_ENTITIES.register(modEventBus);
-        GrowthcraftCellarFluids.FLUID_TYPES.register(modEventBus);
-        GrowthcraftCellarFluids.FLUIDS.register(modEventBus);
+        //GrowthcraftCellarFluids.FLUID_TYPES.register(modEventBus);
+        //GrowthcraftCellarFluids.FLUIDS.register(modEventBus);
         GrowthcraftCellarMenus.MENUS.register(modEventBus);
 
         GrowthcraftCellarRecipes.register(modEventBus);
@@ -86,15 +93,15 @@ public class GrowthcraftCellar {
         GrowthcraftCellarMessages.register();
     }
 
-    public void buildCreativeTabContents(CreativeModeTabEvent.BuildContents event) {
-        if (event.getTab() == GrowthcraftCreativeModeTabs.GROWTHCRAFT_CREATIVE_TAB) {
-            GrowthcraftCellarItems.ITEMS.getEntries().forEach(itemRegistryObject -> {
-                if (!GrowthcraftCellarItems.excludeItemRegistry(itemRegistryObject.getId())) {
-                    event.accept(new ItemStack(itemRegistryObject.get()));
-                }
-            });
-        }
-    }
+//    public void buildCreativeTabContents(CreativeModeTabEvent.BuildContents event) {
+//        if (event.getTab() == GrowthcraftCreativeModeTabs.GROWTHCRAFT_CREATIVE_TAB) {
+//            GrowthcraftCellarItems.ITEMS.getEntries().forEach(itemRegistryObject -> {
+//                if (!GrowthcraftCellarItems.excludeItemRegistry(itemRegistryObject.getId())) {
+//                    event.accept(new ItemStack(itemRegistryObject.get()));
+//                }
+//            });
+//        }
+//    }
 
     @SubscribeEvent
     public void onServerStarting(ServerStartingEvent event) {

--- a/src/main/java/growthcraft/cellar/block/HopsCropBlock.java
+++ b/src/main/java/growthcraft/cellar/block/HopsCropBlock.java
@@ -100,7 +100,7 @@ public class HopsCropBlock extends GrowthcraftCropsRopeBlock {
     }
 
     @Override
-    public boolean isValidBonemealTarget(LevelReader level, BlockPos pos, BlockState state, boolean isClientSide) {
+    public boolean isValidBonemealTarget(BlockGetter level, BlockPos pos, BlockState state, boolean isClientSide) {
         return super.isValidBonemealTarget(level, pos, state, isClientSide) || level.getBlockState(pos.above()).getBlock() instanceof RopeBlock;
     }
 

--- a/src/main/java/growthcraft/cellar/block/entity/BrewKettleBlockEntity.java
+++ b/src/main/java/growthcraft/cellar/block/entity/BrewKettleBlockEntity.java
@@ -27,6 +27,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
@@ -153,7 +154,7 @@ public class BrewKettleBlockEntity extends BlockEntity implements BlockEntityTic
     public Component getDisplayName() {
         return this.customName != null
                 ? this.customName
-                : Component.translatable("container.growthcraft_cellar.brew_kettle");
+                : new TranslatableComponent("container.growthcraft_cellar.brew_kettle");
     }
 
     public void tick() {

--- a/src/main/java/growthcraft/cellar/block/entity/CultureJarBlockEntity.java
+++ b/src/main/java/growthcraft/cellar/block/entity/CultureJarBlockEntity.java
@@ -24,6 +24,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
@@ -115,7 +116,7 @@ public class CultureJarBlockEntity extends BlockEntity implements BlockEntityTic
     public Component getDisplayName() {
         return this.customName != null
                 ? this.customName
-                : Component.translatable("container.growthcraft_cellar.culture_jar");
+                : new TranslatableComponent("container.growthcraft_cellar.culture_jar");
     }
 
     @Override

--- a/src/main/java/growthcraft/cellar/block/entity/FermentationBarrelBlockEntity.java
+++ b/src/main/java/growthcraft/cellar/block/entity/FermentationBarrelBlockEntity.java
@@ -1,5 +1,15 @@
 package growthcraft.cellar.block.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import growthcraft.cellar.init.GrowthcraftCellarBlockEntities;
 import growthcraft.cellar.lib.networking.GrowthcraftCellarMessages;
 import growthcraft.cellar.lib.networking.packet.FermentationBarrelFluidTankPacket;
@@ -11,6 +21,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
@@ -29,7 +40,6 @@ import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
@@ -37,14 +47,6 @@ import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
 
 public class FermentationBarrelBlockEntity extends BlockEntity implements BlockEntityTicker<FermentationBarrelBlockEntity>, MenuProvider {
 
@@ -114,7 +116,7 @@ public class FermentationBarrelBlockEntity extends BlockEntity implements BlockE
     public Component getDisplayName() {
         return this.customName != null
                 ? this.customName
-                : Component.translatable("container.growthcraft_cellar.fermentation_barrel");
+                : new TranslatableComponent("container.growthcraft_cellar.fermentation_barrel");
     }
 
     public void tick() {

--- a/src/main/java/growthcraft/cellar/block/entity/FruitPressBlockEntity.java
+++ b/src/main/java/growthcraft/cellar/block/entity/FruitPressBlockEntity.java
@@ -25,6 +25,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
@@ -118,7 +119,7 @@ public class FruitPressBlockEntity extends BlockEntity implements BlockEntityTic
     public Component getDisplayName() {
         return this.customName != null
                 ? this.customName
-                : Component.translatable("container.growthcraft_cellar.fruit_press");
+                : new TranslatableComponent("container.growthcraft_cellar.fruit_press");
     }
 
     public void tick() {

--- a/src/main/java/growthcraft/cellar/block/entity/RoasterBlockEntity.java
+++ b/src/main/java/growthcraft/cellar/block/entity/RoasterBlockEntity.java
@@ -24,6 +24,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
@@ -115,7 +116,7 @@ public class RoasterBlockEntity extends BlockEntity implements BlockEntityTicker
     public @NotNull Component getDisplayName() {
         return this.customName != null
                 ? this.customName
-                : Component.translatable("container.growthcraft_cellar.roaster");
+                : new TranslatableComponent("container.growthcraft_cellar.roaster");
     }
 
     @Nullable

--- a/src/main/java/growthcraft/cellar/block/entity/renderer/BrewKettleBlockEntityRenderer.java
+++ b/src/main/java/growthcraft/cellar/block/entity/renderer/BrewKettleBlockEntityRenderer.java
@@ -1,8 +1,13 @@
 package growthcraft.cellar.block.entity.renderer;
 
+import java.awt.Color;
+
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
-import com.mojang.math.Axis;
+import com.mojang.math.Matrix3f;
+import com.mojang.math.Matrix4f;
+import com.mojang.math.Quaternion;
+
 import growthcraft.cellar.block.entity.BrewKettleBlockEntity;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -10,14 +15,10 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
+import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
-import org.joml.Matrix3f;
-import org.joml.Matrix4f;
-import org.joml.Quaternionf;
-
-import java.awt.*;
 
 public class BrewKettleBlockEntityRenderer implements BlockEntityRenderer<BrewKettleBlockEntity> {
     @Override
@@ -35,7 +36,8 @@ public class BrewKettleBlockEntityRenderer implements BlockEntityRenderer<BrewKe
 
         float baseOffset = 4.0F / 16F;
         float maxFluidHeight = 15.0F / 16F;
-
+        Quaternion rotation = new Quaternion(null, 90.0F, true);
+        
         if(!blockEntity.getFluidStackInTank(0).isEmpty()) {
 
             FluidStack inputFluidStack = blockEntity.getFluidStackInTank(0);
@@ -44,7 +46,7 @@ public class BrewKettleBlockEntityRenderer implements BlockEntityRenderer<BrewKe
             float inputAmount = inputFluidStack.getAmount();
             float inputFluidHeight = baseOffset + (maxFluidHeight - baseOffset) * inputAmount / inputCapacity;
 
-            renderFluidSingle(poseStack, multiBufferSource, inputFluidStack, 0.0F, inputFluidHeight, 0.0F, Axis.XP.rotationDegrees(90.0F), light, overlay);
+            renderFluidSingle(poseStack, multiBufferSource, inputFluidStack, 0.0F, inputFluidHeight, 0.0F, rotation, light, overlay);
         }
 
         if(!blockEntity.getFluidStackInTank(1).isEmpty()) {
@@ -54,11 +56,11 @@ public class BrewKettleBlockEntityRenderer implements BlockEntityRenderer<BrewKe
             float outputAmount = outputFluidStack.getAmount();
             float outputFluidHeight = baseOffset + (maxFluidHeight - baseOffset) * outputAmount / outputCapacity;
 
-            renderFluidSingle(poseStack, multiBufferSource, outputFluidStack, 0.0F, outputFluidHeight, 0.0F, Axis.XP.rotationDegrees(90.0F), light, overlay);
+            renderFluidSingle(poseStack, multiBufferSource, outputFluidStack, 0.0F, outputFluidHeight, 0.0F, rotation, light, overlay);
         }
     }
 
-    public void renderFluidSingle(PoseStack poseStack, MultiBufferSource buffer, FluidStack fluidStack, float xOffset, float height, float zOffset, Quaternionf rotation, int lightLevel, int overlay) {
+    public void renderFluidSingle(PoseStack poseStack, MultiBufferSource buffer, FluidStack fluidStack, float xOffset, float height, float zOffset, Quaternion rotation, int lightLevel, int overlay) {
         poseStack.pushPose();
         poseStack.translate(0.5F, height, 0.5F);
 
@@ -73,10 +75,13 @@ public class BrewKettleBlockEntityRenderer implements BlockEntityRenderer<BrewKe
 
         poseStack.scale(s, s, s);
 
-        IClientFluidTypeExtensions fluidTypeExtensions = IClientFluidTypeExtensions.of(fluidStack.getFluid());
-        Color color = new Color(fluidTypeExtensions.getTintColor());
+        Fluid fluid = fluidStack.getFluid();
+        FluidAttributes fluidAttributes = fluid.getAttributes();
+        
+        //IClientFluidTypeExtensions fluidTypeExtensions = IClientFluidTypeExtensions.of(fluidStack.getFluid());
+        Color color = new Color(fluidAttributes.getColor());
 
-        TextureAtlasSprite sprite = Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(fluidTypeExtensions.getStillTexture(fluidStack));
+        TextureAtlasSprite sprite = Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(fluidAttributes.getStillTexture(fluidStack));
 
         VertexConsumer vertexBuilder = buffer.getBuffer(RenderType.translucent());
 

--- a/src/main/java/growthcraft/cellar/block/entity/renderer/CultureJarBlockEntityRenderer.java
+++ b/src/main/java/growthcraft/cellar/block/entity/renderer/CultureJarBlockEntityRenderer.java
@@ -1,8 +1,13 @@
 package growthcraft.cellar.block.entity.renderer;
 
+import java.awt.Color;
+
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
-import com.mojang.math.Axis;
+import com.mojang.math.Matrix3f;
+import com.mojang.math.Matrix4f;
+import com.mojang.math.Quaternion;
+
 import growthcraft.cellar.block.entity.CultureJarBlockEntity;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -10,14 +15,10 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
+import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
-import org.joml.Matrix3f;
-import org.joml.Matrix4f;
-import org.joml.Quaternionf;
-
-import java.awt.*;
 
 public class CultureJarBlockEntityRenderer implements BlockEntityRenderer<CultureJarBlockEntity> {
 
@@ -48,23 +49,23 @@ public class CultureJarBlockEntityRenderer implements BlockEntityRenderer<Cultur
 
         //poseStack.popPose();
         // TOP
-        renderFluidSingle(poseStack, multiBufferSource, inputFluidStack, 0.0F, inputFluidHeight, 0.0F,Axis.XP.rotationDegrees(90.0F), light, overlay);
+        renderFluidSingle(poseStack, multiBufferSource, inputFluidStack, 0.0F, inputFluidHeight, 0.0F, new Quaternion(null, 90.0F, true), light, overlay);
         // SOUTH FACING
-        renderFluidSingle(poseStack, multiBufferSource, inputFluidStack, 0.0F, 0.605F, 0.6F, Axis.XP.rotationDegrees(180.0F), light, overlay);
+        renderFluidSingle(poseStack, multiBufferSource, inputFluidStack, 0.0F, 0.605F, 0.6F, new Quaternion(null, 180.0F, true), light, overlay);
         // NORTH FACING
-        renderFluidSingle(poseStack, multiBufferSource, inputFluidStack, 0.0F, -0.35F, 0.355F, Axis.XP.rotationDegrees(0.0F), light, overlay);
+        renderFluidSingle(poseStack, multiBufferSource, inputFluidStack, 0.0F, -0.35F, 0.355F, new Quaternion(null, 0.0F, true), light, overlay);
         // BOTTOM FACING
-        renderFluidSingle(poseStack, multiBufferSource, inputFluidStack, 0.0F, 0.01F, 0.955F, Axis.XP.rotationDegrees(270.0F), light, overlay);
+        renderFluidSingle(poseStack, multiBufferSource, inputFluidStack, 0.0F, 0.01F, 0.955F, new Quaternion(null, 270.0F, true), light, overlay);
         // WEST FACING
-        renderFluidSingle(poseStack, multiBufferSource, inputFluidStack, 0.355F, -0.35F, 0.956F, Axis.YP.rotationDegrees(90.0F), light, overlay);
+        renderFluidSingle(poseStack, multiBufferSource, inputFluidStack, 0.355F, -0.35F, 0.956F, new Quaternion(null, 90.0F, true), light, overlay);
         // EAST FACING
-        renderFluidSingle(poseStack, multiBufferSource, inputFluidStack, 0.6F, -0.35F, 0.0F, Axis.YP.rotationDegrees(270.0F), light, overlay);
+        renderFluidSingle(poseStack, multiBufferSource, inputFluidStack, 0.6F, -0.35F, 0.0F, new Quaternion(null, 270.0F, true), light, overlay);
 
         //poseStack.pushPose();
 
     }
 
-    public void renderFluidSingle(PoseStack poseStack, MultiBufferSource buffer, FluidStack fluidStack, float xOffset, float height, float zOffset, Quaternionf rotation, int lightLevel, int overlay) {
+    public void renderFluidSingle(PoseStack poseStack, MultiBufferSource buffer, FluidStack fluidStack, float xOffset, float height, float zOffset, Quaternion rotation, int lightLevel, int overlay) {
         poseStack.pushPose();
         poseStack.translate(0.5F, height, 0.5F);
 
@@ -79,10 +80,13 @@ public class CultureJarBlockEntityRenderer implements BlockEntityRenderer<Cultur
 
         poseStack.scale(s, s, s);
 
-        IClientFluidTypeExtensions fluidTypeExtensions = IClientFluidTypeExtensions.of(fluidStack.getFluid());
-        Color color = new Color(fluidTypeExtensions.getTintColor());
+        Fluid fluid = fluidStack.getFluid();
+        FluidAttributes fluidAttributes = fluid.getAttributes();
+        
+        //IClientFluidTypeExtensions fluidTypeExtensions = IClientFluidTypeExtensions.of(fluidStack.getFluid());
+        Color color = new Color(fluidAttributes.getColor());
 
-        TextureAtlasSprite sprite = Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(fluidTypeExtensions.getStillTexture(fluidStack));
+        TextureAtlasSprite sprite = Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(fluidAttributes.getStillTexture(fluidStack));
 
         VertexConsumer vertexBuilder = buffer.getBuffer(RenderType.translucent());
 

--- a/src/main/java/growthcraft/cellar/init/GrowthcraftCellarMenus.java
+++ b/src/main/java/growthcraft/cellar/init/GrowthcraftCellarMenus.java
@@ -13,7 +13,7 @@ import net.minecraftforge.registries.RegistryObject;
 public class GrowthcraftCellarMenus {
 
     public static final DeferredRegister<MenuType<?>> MENUS = DeferredRegister.create(
-            ForgeRegistries.MENU_TYPES, Reference.MODID
+            ForgeRegistries.CONTAINERS, Reference.MODID
     );
 
     public static final RegistryObject<MenuType<BrewKettleMenu>> BREW_KETTLE_MENU = registerMenuType(

--- a/src/main/java/growthcraft/cellar/init/client/GrowthcraftCellarItemRenderers.java
+++ b/src/main/java/growthcraft/cellar/init/client/GrowthcraftCellarItemRenderers.java
@@ -7,7 +7,7 @@ import growthcraft.lib.client.GrowthcraftItemColor;
 import growthcraft.lib.client.ItemRendererUtils;
 import net.minecraft.world.item.Item;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.client.event.RegisterColorHandlersEvent;
+import net.minecraftforge.client.event.ColorHandlerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.registries.RegistryObject;
@@ -16,7 +16,7 @@ import net.minecraftforge.registries.RegistryObject;
 public class GrowthcraftCellarItemRenderers {
 
     @SubscribeEvent
-    public static void registerItemRenders(RegisterColorHandlersEvent.Item event) {
+    public static void registerItemRenders(ColorHandlerEvent.Item event) {
         GrowthcraftItemColor itemColor = new GrowthcraftItemColor();
 
         for (RegistryObject<? extends Item> grain : GrowthcraftCellarItems.GRAINS) {

--- a/src/main/java/growthcraft/cellar/lib/networking/GrowthcraftCellarMessages.java
+++ b/src/main/java/growthcraft/cellar/lib/networking/GrowthcraftCellarMessages.java
@@ -34,25 +34,25 @@ public class GrowthcraftCellarMessages {
         net.messageBuilder(BrewKettleFluidTankPacket.class, id(), NetworkDirection.PLAY_TO_CLIENT)
                 .decoder(BrewKettleFluidTankPacket::new)
                 .encoder(BrewKettleFluidTankPacket::toBytes)
-                .consumerMainThread(BrewKettleFluidTankPacket::handle)
+                .consumer(BrewKettleFluidTankPacket::handle)
                 .add();
 
         net.messageBuilder(CultureJarFluidSyncPacket.class, id(), NetworkDirection.PLAY_TO_CLIENT)
                 .decoder(CultureJarFluidSyncPacket::new)
                 .encoder(CultureJarFluidSyncPacket::toBytes)
-                .consumerMainThread(CultureJarFluidSyncPacket::handle)
+                .consumer(CultureJarFluidSyncPacket::handle)
                 .add();
 
         net.messageBuilder(FermentationBarrelFluidTankPacket.class, id(), NetworkDirection.PLAY_TO_CLIENT)
                 .decoder(FermentationBarrelFluidTankPacket::new)
                 .encoder(FermentationBarrelFluidTankPacket::toBytes)
-                .consumerMainThread(FermentationBarrelFluidTankPacket::handle)
+                .consumer(FermentationBarrelFluidTankPacket::handle)
                 .add();
 
         net.messageBuilder(FruitPressFluidTankPacket.class, id(), NetworkDirection.PLAY_TO_CLIENT)
                 .decoder(FruitPressFluidTankPacket::new)
                 .encoder(FruitPressFluidTankPacket::toBytes)
-                .consumerMainThread(FruitPressFluidTankPacket::handle)
+                .consumer(FruitPressFluidTankPacket::handle)
                 .add();
 
     }

--- a/src/main/java/growthcraft/cellar/recipe/BrewKettleRecipe.java
+++ b/src/main/java/growthcraft/cellar/recipe/BrewKettleRecipe.java
@@ -65,7 +65,7 @@ public class BrewKettleRecipe implements Recipe<SimpleContainer> {
     }
 
     @Override
-    public ItemStack assemble(SimpleContainer container, RegistryAccess registryAccess) {
+    public ItemStack assemble(SimpleContainer container) {
         return this.outputFluidStack.getFluid().getBucket().getDefaultInstance();
     }
 
@@ -75,7 +75,7 @@ public class BrewKettleRecipe implements Recipe<SimpleContainer> {
     }
 
     @Override
-    public ItemStack getResultItem(RegistryAccess registryAccess) {
+    public ItemStack getResultItem() {
         return this.outputFluidStack.getFluid().getBucket().getDefaultInstance();
     }
 
@@ -140,6 +140,7 @@ public class BrewKettleRecipe implements Recipe<SimpleContainer> {
         public static final ResourceLocation ID = new ResourceLocation(
                 Reference.MODID,
                 Reference.UnlocalizedName.BREW_KETTLE_RECIPE);
+        private ResourceLocation name;
 
         @Override
         public @NotNull BrewKettleRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
@@ -195,5 +196,25 @@ public class BrewKettleRecipe implements Recipe<SimpleContainer> {
             buffer.writeVarInt(recipe.getByProductChance());
         }
 
+		@Override
+		public RecipeSerializer<?> setRegistryName(ResourceLocation name) {
+			this.name = name;
+			return this;
+		}
+
+		@Override
+		public ResourceLocation getRegistryName() {
+			return name;
+		}
+
+		@Override
+		public Class<RecipeSerializer<?>> getRegistryType() {
+			// TODO Auto-generated method stub
+			return Serializer.<RecipeSerializer<?>>castClass(RecipeSerializer.class);
+		}
+
+		private static <G> Class<G> castClass(Class<?> cls) {
+	        return (Class<G>) cls;
+	    }
     }
 }

--- a/src/main/java/growthcraft/cellar/recipe/CultureJarRecipe.java
+++ b/src/main/java/growthcraft/cellar/recipe/CultureJarRecipe.java
@@ -2,6 +2,7 @@ package growthcraft.cellar.recipe;
 
 import com.google.gson.JsonObject;
 import growthcraft.cellar.GrowthcraftCellar;
+import growthcraft.cellar.recipe.BrewKettleRecipe.Serializer;
 import growthcraft.cellar.shared.Reference;
 import growthcraft.lib.utils.CraftingUtils;
 import net.minecraft.core.RegistryAccess;
@@ -46,7 +47,7 @@ public class CultureJarRecipe implements Recipe<SimpleContainer> {
     }
 
     @Override
-    public ItemStack assemble(SimpleContainer simpleContainer, RegistryAccess registryAccess) {
+    public ItemStack assemble(SimpleContainer simpleContainer) {
         return this.inputItem;
     }
 
@@ -56,7 +57,7 @@ public class CultureJarRecipe implements Recipe<SimpleContainer> {
     }
 
     @Override
-    public ItemStack getResultItem(RegistryAccess registryAccess) {
+    public ItemStack getResultItem() {
         return this.inputItem;
     }
 
@@ -104,6 +105,7 @@ public class CultureJarRecipe implements Recipe<SimpleContainer> {
         public static final ResourceLocation ID = new ResourceLocation(
                 Reference.MODID,
                 Reference.UnlocalizedName.CULTURE_JAR_RECIPE);
+        private ResourceLocation name;
 
         @Override
         public @NotNull CultureJarRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
@@ -140,6 +142,27 @@ public class CultureJarRecipe implements Recipe<SimpleContainer> {
             buffer.writeVarInt(recipe.getRecipeProcessingTime());
             buffer.writeBoolean(recipe.isHeatSourceRequired());
         }
+        
+		@Override
+		public RecipeSerializer<?> setRegistryName(ResourceLocation name) {
+			this.name = name;
+			return this;
+		}
+
+		@Override
+		public ResourceLocation getRegistryName() {
+			return name;
+		}
+
+		@Override
+		public Class<RecipeSerializer<?>> getRegistryType() {
+			// TODO Auto-generated method stub
+			return Serializer.<RecipeSerializer<?>>castClass(RecipeSerializer.class);
+		}
+
+		private static <G> Class<G> castClass(Class<?> cls) {
+	        return (Class<G>) cls;
+	    }
 
     }
 }

--- a/src/main/java/growthcraft/cellar/recipe/CultureJarStarterRecipe.java
+++ b/src/main/java/growthcraft/cellar/recipe/CultureJarStarterRecipe.java
@@ -2,6 +2,7 @@ package growthcraft.cellar.recipe;
 
 import com.google.gson.JsonObject;
 import growthcraft.cellar.GrowthcraftCellar;
+import growthcraft.cellar.recipe.BrewKettleRecipe.Serializer;
 import growthcraft.cellar.shared.Reference;
 import growthcraft.lib.utils.CraftingUtils;
 import net.minecraft.core.RegistryAccess;
@@ -46,7 +47,7 @@ public class CultureJarStarterRecipe implements Recipe<SimpleContainer> {
     }
 
     @Override
-    public ItemStack assemble(SimpleContainer simpleContainer, RegistryAccess registryAccess) {
+    public ItemStack assemble(SimpleContainer simpleContainer) {
         return this.outputItem;
     }
 
@@ -56,7 +57,7 @@ public class CultureJarStarterRecipe implements Recipe<SimpleContainer> {
     }
 
     @Override
-    public ItemStack getResultItem(RegistryAccess registryAccess) {
+    public ItemStack getResultItem() {
         return this.outputItem;
     }
 
@@ -104,6 +105,7 @@ public class CultureJarStarterRecipe implements Recipe<SimpleContainer> {
         public static final ResourceLocation ID = new ResourceLocation(
                 Reference.MODID,
                 Reference.UnlocalizedName.CULTURE_JAR_STARTER_RECIPE);
+        private ResourceLocation name;
 
         @Override
         public @NotNull CultureJarStarterRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
@@ -140,6 +142,27 @@ public class CultureJarStarterRecipe implements Recipe<SimpleContainer> {
             buffer.writeVarInt(recipe.getRecipeProcessingTime());
             buffer.writeBoolean(recipe.isHeatSourceRequired());
         }
+        
+		@Override
+		public RecipeSerializer<?> setRegistryName(ResourceLocation name) {
+			this.name = name;
+			return this;
+		}
+
+		@Override
+		public ResourceLocation getRegistryName() {
+			return name;
+		}
+
+		@Override
+		public Class<RecipeSerializer<?>> getRegistryType() {
+			// TODO Auto-generated method stub
+			return Serializer.<RecipeSerializer<?>>castClass(RecipeSerializer.class);
+		}
+
+		private static <G> Class<G> castClass(Class<?> cls) {
+	        return (Class<G>) cls;
+	    }
 
     }
 }

--- a/src/main/java/growthcraft/cellar/recipe/FermentationBarrelRecipe.java
+++ b/src/main/java/growthcraft/cellar/recipe/FermentationBarrelRecipe.java
@@ -3,6 +3,7 @@ package growthcraft.cellar.recipe;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import growthcraft.cellar.GrowthcraftCellar;
+import growthcraft.cellar.recipe.BrewKettleRecipe.Serializer;
 import growthcraft.cellar.shared.Reference;
 import growthcraft.lib.utils.CraftingUtils;
 import growthcraft.lib.utils.EffectUtils;
@@ -51,7 +52,7 @@ public class FermentationBarrelRecipe implements Recipe<SimpleContainer> {
         this.potionItemStack.setHoverName(
                 this.potionItemStack.getDisplayName().copy()
                         .append(" ")
-                        .append(Component.translatable(this.outputFluidStack.getTranslationKey()))
+                        .append(this.outputFluidStack.getTranslationKey())
         );
 
     }
@@ -121,7 +122,7 @@ public class FermentationBarrelRecipe implements Recipe<SimpleContainer> {
     }
 
     @Override
-    public ItemStack assemble(SimpleContainer simpleContainer, RegistryAccess registryAccess) {
+    public ItemStack assemble(SimpleContainer simpleContainer) {
         return this.inputItemStack;
     }
 
@@ -131,7 +132,7 @@ public class FermentationBarrelRecipe implements Recipe<SimpleContainer> {
     }
 
     @Override
-    public ItemStack getResultItem(RegistryAccess registryAccess) {
+    public ItemStack getResultItem() {
         return this.outputFluidStack.getFluid().getBucket().getDefaultInstance();
     }
 
@@ -196,6 +197,7 @@ public class FermentationBarrelRecipe implements Recipe<SimpleContainer> {
         public static final ResourceLocation ID = new ResourceLocation(
                 Reference.MODID,
                 Reference.UnlocalizedName.FERMENT_BARREL_RECIPE);
+        private ResourceLocation name;
 
         @Override
         public @NotNull FermentationBarrelRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
@@ -250,6 +252,27 @@ public class FermentationBarrelRecipe implements Recipe<SimpleContainer> {
             buffer.writeVarInt(recipe.getProcessingTime());
             buffer.writeVarInt(recipe.getColor().hashCode());
         }
+        
+		@Override
+		public RecipeSerializer<?> setRegistryName(ResourceLocation name) {
+			this.name = name;
+			return this;
+		}
+
+		@Override
+		public ResourceLocation getRegistryName() {
+			return name;
+		}
+
+		@Override
+		public Class<RecipeSerializer<?>> getRegistryType() {
+			// TODO Auto-generated method stub
+			return Serializer.<RecipeSerializer<?>>castClass(RecipeSerializer.class);
+		}
+
+		private static <G> Class<G> castClass(Class<?> cls) {
+	        return (Class<G>) cls;
+	    }
 
     }
 }

--- a/src/main/java/growthcraft/cellar/recipe/FruitPressRecipe.java
+++ b/src/main/java/growthcraft/cellar/recipe/FruitPressRecipe.java
@@ -1,10 +1,13 @@
 package growthcraft.cellar.recipe;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import com.google.gson.JsonObject;
+
 import growthcraft.cellar.GrowthcraftCellar;
 import growthcraft.cellar.shared.Reference;
 import growthcraft.lib.utils.CraftingUtils;
-import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
@@ -16,8 +19,6 @@ import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.fluids.FluidStack;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public class FruitPressRecipe implements Recipe<SimpleContainer> {
 
@@ -50,7 +51,7 @@ public class FruitPressRecipe implements Recipe<SimpleContainer> {
     }
 
     @Override
-    public ItemStack assemble(SimpleContainer container, RegistryAccess registryAccess) {
+    public ItemStack assemble(SimpleContainer container) {
         return this.outputFluidStack.getFluid().getBucket().getDefaultInstance().copy();
     }
 
@@ -60,7 +61,7 @@ public class FruitPressRecipe implements Recipe<SimpleContainer> {
     }
 
     @Override
-    public ItemStack getResultItem(RegistryAccess registryAccess) {
+    public ItemStack getResultItem() {
         return this.outputFluidStack.getFluid().getBucket().getDefaultInstance().copy();
     }
 
@@ -105,6 +106,7 @@ public class FruitPressRecipe implements Recipe<SimpleContainer> {
         public static final ResourceLocation ID = new ResourceLocation(
                 Reference.MODID,
                 Reference.UnlocalizedName.FRUIT_PRESS_RECIPE);
+        private ResourceLocation name;
 
         @Override
         public @NotNull FruitPressRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
@@ -139,6 +141,27 @@ public class FruitPressRecipe implements Recipe<SimpleContainer> {
             buffer.writeVarInt(recipe.getProcessingTime());
         }
 
+		@Override
+		public RecipeSerializer<?> setRegistryName(ResourceLocation name) {
+			this.name = name;
+			return this;
+		}
+
+		@Override
+		public ResourceLocation getRegistryName() {
+			return name;
+		}
+
+		@Override
+		public Class<RecipeSerializer<?>> getRegistryType() {
+			// TODO Auto-generated method stub
+			return Serializer.<RecipeSerializer<?>>castClass(RecipeSerializer.class);
+		}
+
+		private static <G> Class<G> castClass(Class<?> cls) {
+	        return (Class<G>) cls;
+	    }
+        
     }
 
 

--- a/src/main/java/growthcraft/cellar/recipe/RoasterRecipe.java
+++ b/src/main/java/growthcraft/cellar/recipe/RoasterRecipe.java
@@ -1,9 +1,12 @@
 package growthcraft.cellar.recipe;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import com.google.gson.JsonObject;
+
 import growthcraft.cellar.GrowthcraftCellar;
 import growthcraft.cellar.shared.Reference;
-import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
@@ -14,8 +17,6 @@ import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.crafting.CraftingHelper;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public class RoasterRecipe implements Recipe<SimpleContainer> {
 
@@ -44,18 +45,13 @@ public class RoasterRecipe implements Recipe<SimpleContainer> {
     }
 
     @Override
-    public ItemStack assemble(SimpleContainer simpleContainer, RegistryAccess registryAccess) {
+    public ItemStack assemble(SimpleContainer simpleContainer) {
         return this.inputItem;
     }
 
     @Override
     public boolean canCraftInDimensions(int width, int height) {
         return true;
-    }
-
-    @Override
-    public ItemStack getResultItem(RegistryAccess registryAccess) {
-        return this.resultItem;
     }
 
     public ItemStack getResultItem() {
@@ -98,6 +94,7 @@ public class RoasterRecipe implements Recipe<SimpleContainer> {
         public static final ResourceLocation ID = new ResourceLocation(
                 Reference.MODID,
                 Reference.UnlocalizedName.ROASTER_RECIPE);
+        private ResourceLocation name;
 
         @Override
         public @NotNull RoasterRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
@@ -131,6 +128,27 @@ public class RoasterRecipe implements Recipe<SimpleContainer> {
             buffer.writeItemStack(recipe.getResultItem(), false);
             buffer.writeVarInt(recipe.getRecipeProcessingTime());
         }
+        
+		@Override
+		public RecipeSerializer<?> setRegistryName(ResourceLocation name) {
+			this.name = name;
+			return this;
+		}
+
+		@Override
+		public ResourceLocation getRegistryName() {
+			return name;
+		}
+
+		@Override
+		public Class<RecipeSerializer<?>> getRegistryType() {
+			// TODO Auto-generated method stub
+			return Serializer.<RecipeSerializer<?>>castClass(RecipeSerializer.class);
+		}
+
+		private static <G> Class<G> castClass(Class<?> cls) {
+	        return (Class<G>) cls;
+	    }
 
     }
 }

--- a/src/main/java/growthcraft/cellar/screen/RoasterScreen.java
+++ b/src/main/java/growthcraft/cellar/screen/RoasterScreen.java
@@ -8,6 +8,7 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 import org.jetbrains.annotations.NotNull;
@@ -77,9 +78,8 @@ public class RoasterScreen extends AbstractContainerScreen<RoasterMenu> {
     private void renderProgressToolTip(PoseStack poseStack, int mouseX, int mouseY, int x, int y) {
         List<Component> tooltip = new ArrayList<>();
 
-        MutableComponent progressString = Component.translatable(Reference.MODID.concat(".tooltip.roaster.progress"), menu.getRoastingLevel(), menu.getPercentProgress());
+        MutableComponent progressString = new TranslatableComponent(Reference.MODID.concat(".tooltip.roaster.progress"), menu.getRoastingLevel(), menu.getPercentProgress());
         tooltip.add(progressString);
-
         if (isMouseAboveArea(mouseX, mouseY, x + 74, y + 45, 28, 9, 28, 9)) {
             renderTooltip(
                     poseStack,

--- a/src/main/java/growthcraft/core/Growthcraft.java
+++ b/src/main/java/growthcraft/core/Growthcraft.java
@@ -1,11 +1,15 @@
 package growthcraft.core;
 
-import growthcraft.core.init.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import growthcraft.core.init.GrowthcraftBlockEntities;
+import growthcraft.core.init.GrowthcraftBlocks;
+import growthcraft.core.init.GrowthcraftItems;
+import growthcraft.core.init.GrowthcraftLootModifiers;
 import growthcraft.core.init.config.GrowthcraftConfig;
 import growthcraft.core.shared.Reference;
-import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.CreativeModeTabEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -13,8 +17,6 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 @Mod(Reference.MODID)
 @Mod.EventBusSubscriber(modid = Reference.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
@@ -25,8 +27,8 @@ public class Growthcraft {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         modEventBus.addListener(this::setup);
         modEventBus.addListener(this::clientSetupEvent);
-        modEventBus.addListener(GrowthcraftCreativeModeTabs::registerCreativeModeTab);
-        modEventBus.addListener(this::buildCreativeTabContents);
+//        modEventBus.addListener(GrowthcraftCreativeModeTabs::registerCreativeModeTab);
+//        modEventBus.addListener(this::buildCreativeTabContents);
 
         GrowthcraftConfig.loadConfig();
 
@@ -52,14 +54,14 @@ public class Growthcraft {
         // Do nothing
     }
 
-    public void buildCreativeTabContents(CreativeModeTabEvent.BuildContents event) {
-        if(event.getTab() == GrowthcraftCreativeModeTabs.GROWTHCRAFT_CREATIVE_TAB) {
-            GrowthcraftItems.ITEMS.getEntries().forEach(itemRegistryObject -> {
-                if (!GrowthcraftItems.excludeItemRegistry(itemRegistryObject.getId())) {
-                    event.accept(new ItemStack(itemRegistryObject.get()));
-                }
-            });
-        }
-    }
+//    public void buildCreativeTabContents(CreativeModeTabEvent.BuildContents event) {
+//        if(event.getTab() == GrowthcraftCreativeModeTabs.GROWTHCRAFT_CREATIVE_TAB) {
+//            GrowthcraftItems.ITEMS.getEntries().forEach(itemRegistryObject -> {
+//                if (!GrowthcraftItems.excludeItemRegistry(itemRegistryObject.getId())) {
+//                    event.accept(new ItemStack(itemRegistryObject.get()));
+//                }
+//            });
+//        }
+//    }
 
 }

--- a/src/main/java/growthcraft/core/init/GrowthcraftCreativeModeTabs.java
+++ b/src/main/java/growthcraft/core/init/GrowthcraftCreativeModeTabs.java
@@ -1,11 +1,6 @@
 package growthcraft.core.init;
 
-import growthcraft.core.shared.Reference;
-import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.CreativeModeTab;
-import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.event.CreativeModeTabEvent;
 
 public class GrowthcraftCreativeModeTabs {
 
@@ -15,13 +10,13 @@ public class GrowthcraftCreativeModeTabs {
         /* Prevent generation of default public constructor. */
     }
 
-    public static void registerCreativeModeTab(CreativeModeTabEvent.Register event) {
-        GROWTHCRAFT_CREATIVE_TAB = event.registerCreativeModeTab(new ResourceLocation(Reference.MODID, "tab"),
-                builder -> {
-                    builder
-                            .icon(() -> new ItemStack(GrowthcraftItems.CROWBAR_ORANGE.get()))
-                            .title(Component.translatable("item_group." + Reference.MODID + ".tab"));
-                }
-        );
-    }
+//    public static void registerCreativeModeTab(CreativeModeTabEvent.Register event) {
+//        GROWTHCRAFT_CREATIVE_TAB = event.registerCreativeModeTab(new ResourceLocation(Reference.MODID, "tab"),
+//                builder -> {
+//                    builder
+//                            .icon(() -> new ItemStack(GrowthcraftItems.CROWBAR_ORANGE.get()))
+//                            .title(Component.translatable("item_group." + Reference.MODID + ".tab"));
+//                }
+//        );
+//    }
 }

--- a/src/main/java/growthcraft/core/init/GrowthcraftLootModifiers.java
+++ b/src/main/java/growthcraft/core/init/GrowthcraftLootModifiers.java
@@ -3,6 +3,7 @@ package growthcraft.core.init;
 import com.mojang.serialization.Codec;
 import growthcraft.core.loot.GlobalLootModifier;
 import growthcraft.core.shared.Reference;
+import net.minecraftforge.common.loot.GlobalLootModifierSerializer;
 import net.minecraftforge.common.loot.IGlobalLootModifier;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
@@ -10,11 +11,11 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
 public class GrowthcraftLootModifiers {
-    public static final DeferredRegister<Codec<? extends IGlobalLootModifier>> LOOT_MODIFIER_SERIALIZERS =
-            DeferredRegister.create(ForgeRegistries.Keys.GLOBAL_LOOT_MODIFIER_SERIALIZERS, Reference.MODID);
+    public static final DeferredRegister<GlobalLootModifierSerializer<?>> LOOT_MODIFIER_SERIALIZERS =
+            DeferredRegister.create(ForgeRegistries.Keys.LOOT_MODIFIER_SERIALIZERS, Reference.MODID);
 
-    public static final RegistryObject<Codec<? extends IGlobalLootModifier>> GLOBAL_BLOCK_LOOT_MODIFIER =
-            LOOT_MODIFIER_SERIALIZERS.register("global_block_loot_modifier", GlobalLootModifier.LOOT_MODIFIER);
+//    public static final RegistryObject<Codec<? extends IGlobalLootModifier>> GLOBAL_BLOCK_LOOT_MODIFIER =
+//            LOOT_MODIFIER_SERIALIZERS.register("global_block_loot_modifier", GlobalLootModifier.LOOT_MODIFIER);
 
     public static void register(IEventBus bus) {
         LOOT_MODIFIER_SERIALIZERS.register(bus);

--- a/src/main/java/growthcraft/core/loot/BeesNestLootModifier.java
+++ b/src/main/java/growthcraft/core/loot/BeesNestLootModifier.java
@@ -13,6 +13,7 @@ import net.minecraftforge.common.loot.LootModifier;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
 import java.util.function.Supplier;
 
 public class BeesNestLootModifier extends LootModifier {
@@ -28,7 +29,7 @@ public class BeesNestLootModifier extends LootModifier {
     }
 
     @Override
-    protected @NotNull ObjectArrayList<ItemStack> doApply(ObjectArrayList<ItemStack> generatedLoot, LootContext context) {
+    protected @NotNull List<ItemStack> doApply(List<ItemStack> generatedLoot, LootContext context) {
         generatedLoot.add(new ItemStack(item));
         return generatedLoot;
     }

--- a/src/main/java/growthcraft/core/loot/GlobalLootModifier.java
+++ b/src/main/java/growthcraft/core/loot/GlobalLootModifier.java
@@ -13,6 +13,7 @@ import net.minecraftforge.common.loot.LootModifier;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
 import java.util.function.Supplier;
 
 public class GlobalLootModifier extends LootModifier {
@@ -28,7 +29,7 @@ public class GlobalLootModifier extends LootModifier {
     }
 
     @Override
-    protected @NotNull ObjectArrayList<ItemStack> doApply(ObjectArrayList<ItemStack> generatedLoot, LootContext context) {
+    protected @NotNull List<ItemStack> doApply(List<ItemStack> generatedLoot, LootContext context) {
         generatedLoot.add(new ItemStack(item));
         return generatedLoot;
     }

--- a/src/main/java/growthcraft/core/shared/Reference.java
+++ b/src/main/java/growthcraft/core/shared/Reference.java
@@ -1,16 +1,24 @@
 package growthcraft.core.shared;
 
+import growthcraft.cellar.init.GrowthcraftCellarBlocks;
 import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.ItemStack;
 
 public class Reference {
     public static final String MODID = "growthcraft";
     public static final String NAME = "Growthcraft";
     public static final String NAME_SHORT = "core";
     public static final String VERSION = "8.1.0";
-
+    public static String CREATIVE_TAB = "Growthcraft";
+    
+    public static final CreativeModeTab ITEM_GROUP = new CreativeModeTab(CREATIVE_TAB) {
+        @Override
+        public ItemStack makeIcon() {
+            return new ItemStack(GrowthcraftCellarBlocks.FERMENTATION_BARREL_OAK.get());
+        }
+    };
+    
     private Reference() { /* Prevent default public constructor */ }
-
-    public static CreativeModeTab CREATIVE_TAB;
 
     public static class UnlocalizedName {
         public static final String CROWBAR_BLACK = "crowbar_black";
@@ -58,6 +66,8 @@ public class Reference {
 
         private UnlocalizedName() { /* Disable default public constructor. */ }
 
+
+        
     }
 
 }

--- a/src/main/java/growthcraft/lib/block/GrowthcraftButtonBlock.java
+++ b/src/main/java/growthcraft/lib/block/GrowthcraftButtonBlock.java
@@ -1,14 +1,13 @@
 package growthcraft.lib.block;
 
-import net.minecraft.world.level.block.ButtonBlock;
 import net.minecraft.world.level.block.SoundType;
-import net.minecraft.world.level.block.state.properties.BlockSetType;
+import net.minecraft.world.level.block.WoodButtonBlock;
 import net.minecraft.world.level.material.Material;
 
-public class GrowthcraftButtonBlock extends ButtonBlock {
+public class GrowthcraftButtonBlock extends WoodButtonBlock {
 
     public GrowthcraftButtonBlock() {
-        super(getInitProperties(Material.DECORATION), BlockSetType.OAK, 30, true);
+        super(getInitProperties(Material.WOOD));
     }
 
     private static Properties getInitProperties(Material material) {

--- a/src/main/java/growthcraft/lib/block/GrowthcraftCropsRopeBlock.java
+++ b/src/main/java/growthcraft/lib/block/GrowthcraftCropsRopeBlock.java
@@ -231,7 +231,7 @@ public class GrowthcraftCropsRopeBlock extends BushBlock implements Bonemealable
     }
 
     @Override
-    public boolean isValidBonemealTarget(LevelReader level, BlockPos blockPos, BlockState state, boolean isClientSide) {
+    public boolean isValidBonemealTarget(BlockGetter level, BlockPos blockPos, BlockState state, boolean isClientSide) {
         return !this.isMaxAge(state);
     }
 
@@ -309,5 +309,7 @@ public class GrowthcraftCropsRopeBlock extends BushBlock implements Bonemealable
     public boolean canBeConnectedTo(BlockState state, BlockGetter world, BlockPos pos, Direction facing) {
         return BlockStateUtils.isRopeBlock(state);
     }
+
+
 
 }

--- a/src/main/java/growthcraft/lib/block/GrowthcraftDoorBlock.java
+++ b/src/main/java/growthcraft/lib/block/GrowthcraftDoorBlock.java
@@ -2,7 +2,6 @@ package growthcraft.lib.block;
 
 import net.minecraft.world.level.block.DoorBlock;
 import net.minecraft.world.level.block.SoundType;
-import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.material.MaterialColor;
 
@@ -16,7 +15,7 @@ public class GrowthcraftDoorBlock extends DoorBlock {
     }
 
     public GrowthcraftDoorBlock(Properties properties) {
-        super(properties, BlockSetType.OAK);
+        super(properties);
     }
 
     private static Properties getInitProperties(Material material) {

--- a/src/main/java/growthcraft/lib/block/GrowthcraftFenceGateBlock.java
+++ b/src/main/java/growthcraft/lib/block/GrowthcraftFenceGateBlock.java
@@ -2,7 +2,6 @@ package growthcraft.lib.block;
 
 import net.minecraft.world.level.block.FenceGateBlock;
 import net.minecraft.world.level.block.SoundType;
-import net.minecraft.world.level.block.state.properties.WoodType;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.material.MaterialColor;
 
@@ -16,7 +15,7 @@ public class GrowthcraftFenceGateBlock extends FenceGateBlock {
     }
 
     public GrowthcraftFenceGateBlock(Properties properties) {
-        super(properties, WoodType.OAK);
+        super(properties);
     }
 
     private static Properties getInitProperties(Material material) {

--- a/src/main/java/growthcraft/lib/block/GrowthcraftPressurePlateBlock.java
+++ b/src/main/java/growthcraft/lib/block/GrowthcraftPressurePlateBlock.java
@@ -2,7 +2,6 @@ package growthcraft.lib.block;
 
 import net.minecraft.world.level.block.PressurePlateBlock;
 import net.minecraft.world.level.block.SoundType;
-import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.material.Material;
 
 public class GrowthcraftPressurePlateBlock extends PressurePlateBlock {
@@ -15,7 +14,7 @@ public class GrowthcraftPressurePlateBlock extends PressurePlateBlock {
     }
 
     public GrowthcraftPressurePlateBlock(Sensitivity sensitivity, Properties properties) {
-        super(sensitivity, properties, BlockSetType.OAK);
+        super(sensitivity, properties);
     }
 
     private static Properties getInitProperties(Material material) {

--- a/src/main/java/growthcraft/lib/block/GrowthcraftTrapDoorBlock.java
+++ b/src/main/java/growthcraft/lib/block/GrowthcraftTrapDoorBlock.java
@@ -2,7 +2,6 @@ package growthcraft.lib.block;
 
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.TrapDoorBlock;
-import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.material.Material;
 
 public class GrowthcraftTrapDoorBlock extends TrapDoorBlock {
@@ -15,7 +14,7 @@ public class GrowthcraftTrapDoorBlock extends TrapDoorBlock {
     }
 
     public GrowthcraftTrapDoorBlock(Properties properties) {
-        super(properties, BlockSetType.OAK);
+        super(properties);
     }
 
     private static Properties getInitProperties(Material material) {

--- a/src/main/java/growthcraft/lib/client/BlockRendererUtils.java
+++ b/src/main/java/growthcraft/lib/client/BlockRendererUtils.java
@@ -1,24 +1,24 @@
 package growthcraft.lib.client;
 
+import java.util.Collection;
+
 import growthcraft.lib.utils.ColorUtils;
 import net.minecraft.client.color.block.BlockColor;
 import net.minecraft.world.level.block.Block;
-import net.minecraftforge.client.event.RegisterColorHandlersEvent;
+import net.minecraftforge.client.event.ColorHandlerEvent;
 import net.minecraftforge.registries.RegistryObject;
-
-import java.util.Collection;
 
 public class BlockRendererUtils {
 
-    public static void registerBlocks(RegisterColorHandlersEvent.Block handler, BlockColor blockColor, Collection<RegistryObject<Block>> blocks) {
+    public static void registerBlocks(ColorHandlerEvent.Block handler, BlockColor blockColor, Collection<RegistryObject<Block>> blocks) {
         if (blocks.isEmpty()) return;
         blocks.stream()
                 .filter(RegistryObject::isPresent)
                 .map(RegistryObject::get)
-                .forEach(block -> handler.register(blockColor, block));
+                .forEach(block -> handler.getBlockColors().register(blockColor, block));
     }
 
-    public static void registerBlock(RegisterColorHandlersEvent.Block handler, ColorUtils.GrowthcraftColor color, Block block) {
+    public static void registerBlock(ColorHandlerEvent.Block handler, ColorUtils.GrowthcraftColor color, Block block) {
         handler.getBlockColors().register((blockstate, reader, pos, i) -> color.toIntValue(), block);
     }
 

--- a/src/main/java/growthcraft/lib/client/ClientFluidTypeExtensions.java
+++ b/src/main/java/growthcraft/lib/client/ClientFluidTypeExtensions.java
@@ -6,7 +6,7 @@ import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
 import org.apache.commons.lang3.function.TriFunction;
-import org.joml.Vector3f;
+import com.mojang.math.Vector3f;
 
 public class ClientFluidTypeExtensions implements IClientFluidTypeExtensions {
     public final String modid;

--- a/src/main/java/growthcraft/lib/client/ItemRendererUtils.java
+++ b/src/main/java/growthcraft/lib/client/ItemRendererUtils.java
@@ -1,24 +1,24 @@
 package growthcraft.lib.client;
 
+import java.util.Collection;
+
 import net.minecraft.client.color.item.ItemColor;
 import net.minecraft.world.item.Item;
-import net.minecraftforge.client.event.RegisterColorHandlersEvent;
+import net.minecraftforge.client.event.ColorHandlerEvent;
 import net.minecraftforge.registries.RegistryObject;
-
-import java.util.Collection;
 
 public class ItemRendererUtils {
 
-    public static void registerItems(RegisterColorHandlersEvent.Item handler, ItemColor itemColor, Collection<RegistryObject<Item>> items) {
+    public static void registerItems(ColorHandlerEvent.Item handler, ItemColor itemColor, Collection<RegistryObject<Item>> items) {
         if (items.isEmpty()) return;
         items.stream()
                 .filter(RegistryObject::isPresent)
                 .map(RegistryObject::get)
-                .forEach(item -> handler.register(itemColor, item));
+                .forEach(item -> handler.getItemColors().register(itemColor, item));
     }
 
-    public static void registerItem(RegisterColorHandlersEvent.Item handler, ItemColor itemColor, Item item) {
-       handler.register(itemColor, item);
+    public static void registerItem(ColorHandlerEvent.Item handler, ItemColor itemColor, Item item) {
+       handler.getItemColors().register(itemColor, item);
     }
 
 }

--- a/src/main/java/growthcraft/lib/fluid/FluidRegistryContainer.java
+++ b/src/main/java/growthcraft/lib/fluid/FluidRegistryContainer.java
@@ -1,7 +1,15 @@
 package growthcraft.lib.fluid;
 
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import com.mojang.blaze3d.shaders.FogShape;
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.math.Vector3f;
+
 import growthcraft.lib.client.ClientFluidTypeExtensions;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
@@ -25,12 +33,6 @@ import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.RegistryObject;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.joml.Vector3f;
-
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 public class FluidRegistryContainer {
     public final RegistryObject<FluidType> type;

--- a/src/main/java/growthcraft/lib/fluid/MilkingBucketFluidRegistryContainer.java
+++ b/src/main/java/growthcraft/lib/fluid/MilkingBucketFluidRegistryContainer.java
@@ -2,6 +2,8 @@ package growthcraft.lib.fluid;
 
 import com.mojang.blaze3d.shaders.FogShape;
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.math.Vector3f;
+
 import growthcraft.lib.client.ClientFluidTypeExtensions;
 import growthcraft.milk.item.MilkingBucketItem;
 import net.minecraft.client.Camera;
@@ -27,7 +29,6 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.RegistryObject;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.joml.Vector3f;
 
 import java.util.function.Consumer;
 import java.util.function.Supplier;

--- a/src/main/java/growthcraft/lib/kaupenjoe/screen/renderer/FluidTankRenderer.java
+++ b/src/main/java/growthcraft/lib/kaupenjoe/screen/renderer/FluidTankRenderer.java
@@ -3,6 +3,8 @@ package growthcraft.lib.kaupenjoe.screen.renderer;
 import com.google.common.base.Preconditions;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
+import com.mojang.math.Matrix4f;
+
 import growthcraft.core.shared.Reference;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
@@ -10,17 +12,16 @@ import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
-import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.joml.Matrix4f;
 
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -184,7 +185,7 @@ public class FluidTankRenderer {
         Fluid fluidType = fluidStack.getFluid();
         try {
             if (fluidType.isSame(Fluids.EMPTY)) {
-                MutableComponent amountString = Component.translatable(Reference.MODID.concat(".tooltip.liquid.empty"));
+                MutableComponent amountString = new TranslatableComponent(Reference.MODID.concat(".tooltip.liquid.empty"));
                 tooltip.add(amountString.withStyle(ChatFormatting.GRAY));
                 return tooltip;
             }
@@ -196,10 +197,10 @@ public class FluidTankRenderer {
             long milliBuckets = (amount * 1000) / FluidType.BUCKET_VOLUME;
 
             if (tooltipMode == TooltipMode.SHOW_AMOUNT_AND_CAPACITY) {
-                MutableComponent amountString = Component.translatable(Reference.MODID.concat(".tooltip.liquid.amount.with.capacity"), nf.format(milliBuckets), nf.format(capacity));
+                MutableComponent amountString = new TranslatableComponent(Reference.MODID.concat(".tooltip.liquid.amount.with.capacity"), nf.format(milliBuckets), nf.format(capacity));
                 tooltip.add(amountString.withStyle(ChatFormatting.GRAY));
             } else if (tooltipMode == TooltipMode.SHOW_AMOUNT) {
-                MutableComponent amountString = Component.translatable(Reference.MODID.concat(".tooltip.liquid.amount"), nf.format(milliBuckets));
+                MutableComponent amountString = new TranslatableComponent(Reference.MODID.concat(".tooltip.liquid.amount"), nf.format(milliBuckets));
                 tooltip.add(amountString.withStyle(ChatFormatting.GRAY));
             }
         } catch (RuntimeException e) {

--- a/src/main/java/growthcraft/lib/utils/ColorUtils.java
+++ b/src/main/java/growthcraft/lib/utils/ColorUtils.java
@@ -1,11 +1,12 @@
 package growthcraft.lib.utils;
 
 import net.minecraft.client.color.item.ItemColor;
-import org.joml.Vector3f;
 
 import java.awt.*;
 import java.util.HashMap;
 import java.util.Map;
+
+import com.mojang.math.Vector3f;
 
 public class ColorUtils {
     public static class GrowthcraftColor {

--- a/src/main/java/growthcraft/milk/GrowthcraftMilk.java
+++ b/src/main/java/growthcraft/milk/GrowthcraftMilk.java
@@ -1,7 +1,15 @@
 package growthcraft.milk;
 
-import growthcraft.core.init.GrowthcraftCreativeModeTabs;
-import growthcraft.milk.init.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import growthcraft.milk.init.GrowthcraftMilkBlockEntities;
+import growthcraft.milk.init.GrowthcraftMilkBlocks;
+import growthcraft.milk.init.GrowthcraftMilkFluids;
+import growthcraft.milk.init.GrowthcraftMilkItems;
+import growthcraft.milk.init.GrowthcraftMilkMenus;
+import growthcraft.milk.init.GrowthcraftMilkRecipes;
+import growthcraft.milk.init.LivingDropLootModifier;
 import growthcraft.milk.init.client.GrowthcraftMilkBlockEntityRenderers;
 import growthcraft.milk.init.client.GrowthcraftMilkBlockRenderers;
 import growthcraft.milk.init.config.GrowthcraftMilkConfig;
@@ -11,10 +19,8 @@ import growthcraft.milk.screen.MixingVatScreen;
 import growthcraft.milk.screen.PancheonScreen;
 import growthcraft.milk.shared.Reference;
 import net.minecraft.client.gui.screens.MenuScreens;
-import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.CreativeModeTabEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -22,8 +28,6 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 
 @Mod(Reference.MODID)
@@ -35,7 +39,7 @@ public class GrowthcraftMilk {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         modEventBus.addListener(this::setup);
         modEventBus.addListener(this::clientSetupEvent);
-        modEventBus.addListener(this::buildCreativeTabContents);
+//        modEventBus.addListener(this::buildCreativeTabContents);
         modEventBus.addListener(this::onRegisterRenderers);
 
         // Config
@@ -45,8 +49,8 @@ public class GrowthcraftMilk {
         GrowthcraftMilkBlocks.BLOCKS.register(modEventBus);
         GrowthcraftMilkItems.ITEMS.register(modEventBus);
         GrowthcraftMilkBlockEntities.BLOCK_ENTITIES.register(modEventBus);
-        GrowthcraftMilkFluids.FLUID_TYPES.register(modEventBus);
-        GrowthcraftMilkFluids.FLUIDS.register(modEventBus);
+        //GrowthcraftMilkFluids.FLUID_TYPES.register(modEventBus);
+        //GrowthcraftMilkFluids.FLUIDS.register(modEventBus);
         GrowthcraftMilkMenus.MENUS.register(modEventBus);
 
         GrowthcraftMilkRecipes.register(modEventBus);
@@ -66,15 +70,15 @@ public class GrowthcraftMilk {
         GrowthcraftMilkMessages.register();
     }
 
-    public void buildCreativeTabContents(CreativeModeTabEvent.BuildContents event) {
-        if (event.getTab() == GrowthcraftCreativeModeTabs.GROWTHCRAFT_CREATIVE_TAB) {
-            GrowthcraftMilkItems.ITEMS.getEntries().forEach(itemRegistryObject -> {
-                if (!GrowthcraftMilkItems.excludeItemRegistry(itemRegistryObject.getId())) {
-                    event.accept(new ItemStack(itemRegistryObject.get()));
-                }
-            });
-        }
-    }
+//    public void buildCreativeTabContents(CreativeModeTabEvent.BuildContents event) {
+//        if (event.getTab() == GrowthcraftCreativeModeTabs.GROWTHCRAFT_CREATIVE_TAB) {
+//            GrowthcraftMilkItems.ITEMS.getEntries().forEach(itemRegistryObject -> {
+//                if (!GrowthcraftMilkItems.excludeItemRegistry(itemRegistryObject.getId())) {
+//                    event.accept(new ItemStack(itemRegistryObject.get()));
+//                }
+//            });
+//        }
+//    }
 
     @SubscribeEvent
     public void onServerStarting(ServerStartingEvent event) {

--- a/src/main/java/growthcraft/milk/block/CheesePressBlock.java
+++ b/src/main/java/growthcraft/milk/block/CheesePressBlock.java
@@ -121,11 +121,11 @@ public class CheesePressBlock extends BaseEntityBlock {
             if (player.getItemInHand(interactionHand).getItem() == GrowthcraftItems.WRENCH.get()) {
                 if (!player.isCrouching()) {
                     // Then tighten the cheese press.
-                    level.playSound(null, blockPos, SoundEvents.CHAIN_PLACE, SoundSource.BLOCKS);
+                    level.playSound(null, blockPos, SoundEvents.CHAIN_PLACE, SoundSource.BLOCKS, 1.0F, 1.0F);
                     level.setBlock(blockPos, blockState.setValue(ROTATION, blockEntity.doRotation(true)), Block.UPDATE_ALL_IMMEDIATE);
                 } else {
                     // Then loosen the cheese press and extract the result item.
-                    level.playSound(null, blockPos, SoundEvents.CHAIN_BREAK, SoundSource.BLOCKS);
+                    level.playSound(null, blockPos, SoundEvents.CHAIN_BREAK, SoundSource.BLOCKS, 1.0F, 1.0F);
                     level.setBlock(blockPos, blockState.setValue(ROTATION, blockEntity.doRotation(false)), Block.UPDATE_ALL_IMMEDIATE);
 
                     // Retrieve the itemstack in the output slot.

--- a/src/main/java/growthcraft/milk/block/entity/ChurnBlockEntity.java
+++ b/src/main/java/growthcraft/milk/block/entity/ChurnBlockEntity.java
@@ -24,6 +24,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
@@ -116,7 +117,7 @@ public class ChurnBlockEntity extends BlockEntity implements BlockEntityTicker<C
     public Component getDisplayName() {
         return this.customName != null
                 ? this.customName
-                : Component.translatable("container.growthcraft_milk.churn");
+                : new TranslatableComponent("container.growthcraft_milk.churn");
     }
 
     @Nullable
@@ -142,9 +143,9 @@ public class ChurnBlockEntity extends BlockEntity implements BlockEntityTicker<C
             boolean plungerState = blockState.getValue(PLUNGED);
 
             if(plungerState) {
-                level.playSound(null, this.getBlockPos(), SoundEvents.WOODEN_BUTTON_CLICK_OFF, SoundSource.BLOCKS);
+                level.playSound(null, this.getBlockPos(), SoundEvents.WOODEN_BUTTON_CLICK_OFF, SoundSource.BLOCKS, 1.0F, 1.0F);
             } else {
-                level.playSound(null, this.getBlockPos(), SoundEvents.WOODEN_BUTTON_CLICK_ON, SoundSource.BLOCKS);
+                level.playSound(null, this.getBlockPos(), SoundEvents.WOODEN_BUTTON_CLICK_ON, SoundSource.BLOCKS, 1.0F, 1.0F);
                 tryPlunger();
             }
 

--- a/src/main/java/growthcraft/milk/block/entity/MixingVatBlockEntity.java
+++ b/src/main/java/growthcraft/milk/block/entity/MixingVatBlockEntity.java
@@ -26,6 +26,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
@@ -133,7 +134,7 @@ public class MixingVatBlockEntity extends BlockEntity implements BlockEntityTick
     public @NotNull Component getDisplayName() {
         return this.customName != null
                 ? this.customName
-                : Component.translatable("container.growthcraft_milk.mixing_vat");
+                : new TranslatableComponent("container.growthcraft_milk.mixing_vat");
     }
 
     @Nullable
@@ -504,7 +505,7 @@ public class MixingVatBlockEntity extends BlockEntity implements BlockEntityTick
 
     public void playSound(String sound) {
         if (Objects.equals(sound, "open") && this.level != null) {
-            this.level.playSound(null, this.getBlockPos(), SoundEvents.IRON_DOOR_OPEN, SoundSource.BLOCKS);
+            this.level.playSound(null, this.getBlockPos(), SoundEvents.IRON_DOOR_OPEN, SoundSource.BLOCKS, 1.0F, 1.0F);
         }
     }
 

--- a/src/main/java/growthcraft/milk/block/entity/PancheonBlockEntity.java
+++ b/src/main/java/growthcraft/milk/block/entity/PancheonBlockEntity.java
@@ -20,6 +20,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
@@ -114,7 +115,7 @@ public class PancheonBlockEntity extends BlockEntity implements BlockEntityTicke
 
     @Override
     public Component getDisplayName() {
-        return Component.translatable("container.growthcraft_milk.pancheon");
+        return new TranslatableComponent("container.growthcraft_milk.pancheon");
     }
 
     @Nullable

--- a/src/main/java/growthcraft/milk/block/entity/renderer/MixingVatBlockEntityRenderer.java
+++ b/src/main/java/growthcraft/milk/block/entity/renderer/MixingVatBlockEntityRenderer.java
@@ -1,8 +1,13 @@
 package growthcraft.milk.block.entity.renderer;
 
+import java.awt.Color;
+
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
-import com.mojang.math.Axis;
+import com.mojang.math.Matrix3f;
+import com.mojang.math.Matrix4f;
+import com.mojang.math.Quaternion;
+
 import growthcraft.milk.block.entity.MixingVatBlockEntity;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -10,14 +15,10 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
+import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
-import org.joml.Matrix3f;
-import org.joml.Matrix4f;
-import org.joml.Quaternionf;
-
-import java.awt.*;
 
 public class MixingVatBlockEntityRenderer implements BlockEntityRenderer<MixingVatBlockEntity> {
     @Override
@@ -35,6 +36,7 @@ public class MixingVatBlockEntityRenderer implements BlockEntityRenderer<MixingV
 
         float baseOffset = 4.0F / 16F;
         float maxFluidHeight = 14.0F / 16F;
+        Quaternion rotation = new Quaternion(null, 90.0F, true);
 
         if(!blockEntity.getFluidStackInTank(0).isEmpty()) {
 
@@ -44,7 +46,7 @@ public class MixingVatBlockEntityRenderer implements BlockEntityRenderer<MixingV
             float inputAmount = inputFluidStack.getAmount();
             float inputFluidHeight = baseOffset + (maxFluidHeight - baseOffset) * inputAmount / inputCapacity;
 
-            renderFluidSingle(poseStack, multiBufferSource, inputFluidStack, 0.0F, inputFluidHeight, 0.0F, Axis.XP.rotationDegrees(90.0F), light, overlay);
+            renderFluidSingle(poseStack, multiBufferSource, inputFluidStack, 0.0F, inputFluidHeight, 0.0F, rotation, light, overlay);
         }
 
         if(!blockEntity.getFluidStackInTank(1).isEmpty()) {
@@ -54,11 +56,11 @@ public class MixingVatBlockEntityRenderer implements BlockEntityRenderer<MixingV
             float outputAmount = outputFluidStack.getAmount();
             float outputFluidHeight = baseOffset + (maxFluidHeight - baseOffset) * outputAmount / outputCapacity;
 
-            renderFluidSingle(poseStack, multiBufferSource, outputFluidStack, 0.0F, outputFluidHeight, 0.0F, Axis.XP.rotationDegrees(90.0F), light, overlay);
+            renderFluidSingle(poseStack, multiBufferSource, outputFluidStack, 0.0F, outputFluidHeight, 0.0F, rotation, light, overlay);
         }
     }
 
-    public void renderFluidSingle(PoseStack poseStack, MultiBufferSource buffer, FluidStack fluidStack, float xOffset, float height, float zOffset, Quaternionf rotation, int lightLevel, int overlay) {
+    public void renderFluidSingle(PoseStack poseStack, MultiBufferSource buffer, FluidStack fluidStack, float xOffset, float height, float zOffset, Quaternion rotation, int lightLevel, int overlay) {
         poseStack.pushPose();
         poseStack.translate(0.5F, height, 0.5F);
 
@@ -72,11 +74,14 @@ public class MixingVatBlockEntityRenderer implements BlockEntityRenderer<MixingV
         poseStack.mulPose(rotation);
 
         poseStack.scale(s, s, s);
+        
+        Fluid fluid = fluidStack.getFluid();
+        FluidAttributes fluidAttributes = fluid.getAttributes();
 
-        IClientFluidTypeExtensions fluidTypeExtensions = IClientFluidTypeExtensions.of(fluidStack.getFluid());
-        Color color = new Color(fluidTypeExtensions.getTintColor());
+        //IClientFluidTypeExtensions fluidTypeExtensions = IClientFluidTypeExtensions.of(fluidStack.getFluid());
+        Color color = new Color(fluidAttributes.getColor());
 
-        TextureAtlasSprite sprite = Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(fluidTypeExtensions.getStillTexture(fluidStack));
+        TextureAtlasSprite sprite = Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(fluidAttributes.getStillTexture(fluidStack));
 
         VertexConsumer vertexBuilder = buffer.getBuffer(RenderType.translucent());
 

--- a/src/main/java/growthcraft/milk/block/entity/renderer/PancheonBlockEntityRenderer.java
+++ b/src/main/java/growthcraft/milk/block/entity/renderer/PancheonBlockEntityRenderer.java
@@ -1,8 +1,13 @@
 package growthcraft.milk.block.entity.renderer;
 
+import java.awt.Color;
+
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
-import com.mojang.math.Axis;
+import com.mojang.math.Matrix3f;
+import com.mojang.math.Matrix4f;
+import com.mojang.math.Quaternion;
+
 import growthcraft.milk.block.entity.PancheonBlockEntity;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -10,12 +15,9 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
-import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
-import org.joml.Matrix3f;
-import org.joml.Matrix4f;
-
-import java.awt.*;
 
 public class PancheonBlockEntityRenderer implements BlockEntityRenderer<PancheonBlockEntity> {
 
@@ -63,13 +65,16 @@ public class PancheonBlockEntityRenderer implements BlockEntityRenderer<Pancheon
         int alpha = 2 * 255;
 
         poseStack.translate(w, 0.0F, w);
-        poseStack.mulPose(Axis.XP.rotationDegrees(90.0F));
+        poseStack.mulPose(new Quaternion(null, 90.0F, true));
         poseStack.scale(s, s, s);
 
-        IClientFluidTypeExtensions fluidTypeExtensions = IClientFluidTypeExtensions.of(fluidStack.getFluid());
-        Color color = new Color(fluidTypeExtensions.getTintColor());
+        Fluid fluid = fluidStack.getFluid();
+        FluidAttributes fluidAttributes = fluid.getAttributes();
+        
+        //IClientFluidTypeExtensions fluidTypeExtensions = IClientFluidTypeExtensions.of(fluidStack.getFluid());
+        Color color = new Color(fluidAttributes.getColor());
 
-        TextureAtlasSprite sprite = Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(fluidTypeExtensions.getStillTexture(fluidStack));
+        TextureAtlasSprite sprite = Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(fluidAttributes.getStillTexture(fluidStack));
 
         VertexConsumer vertexBuilder = buffer.getBuffer(RenderType.translucent());
 

--- a/src/main/java/growthcraft/milk/init/GrowthcraftMilkMenus.java
+++ b/src/main/java/growthcraft/milk/init/GrowthcraftMilkMenus.java
@@ -15,7 +15,7 @@ import net.minecraftforge.registries.RegistryObject;
 public class GrowthcraftMilkMenus {
 
     public static final DeferredRegister<MenuType<?>> MENUS = DeferredRegister.create(
-            ForgeRegistries.MENU_TYPES, Reference.MODID
+            ForgeRegistries.CONTAINERS, Reference.MODID
     );
 
     public static final RegistryObject<MenuType<ChurnMenu>> CHURN_MENU =

--- a/src/main/java/growthcraft/milk/init/LivingDropLootModifier.java
+++ b/src/main/java/growthcraft/milk/init/LivingDropLootModifier.java
@@ -16,7 +16,7 @@ import java.util.Collection;
 public class LivingDropLootModifier {
     @SubscribeEvent
     public void onLivingDropsEvent(LivingDropsEvent event) {
-        LivingEntity entity = event.getEntity();
+        LivingEntity entity = event.getEntityLiving();
         Level level = entity.getLevel();
 
         if(!level.getGameRules().getBoolean(GameRules.RULE_DOMOBLOOT)) {

--- a/src/main/java/growthcraft/milk/init/client/GrowthcraftMilkBlockRenderers.java
+++ b/src/main/java/growthcraft/milk/init/client/GrowthcraftMilkBlockRenderers.java
@@ -7,7 +7,7 @@ import growthcraft.milk.shared.Reference;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.client.event.RegisterColorHandlersEvent;
+import net.minecraftforge.client.event.ColorHandlerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -42,7 +42,7 @@ public class GrowthcraftMilkBlockRenderers {
     }
 
     @SubscribeEvent
-    public static void registerBlockRenders(RegisterColorHandlersEvent.Block event) {
+    public static void registerBlockRenders(ColorHandlerEvent.Block event) {
         BlockRendererUtils.registerBlock(event, Reference.ItemColor.APPENZELLER_CHEESE, GrowthcraftMilkBlocks.APPENZELLER_CHEESE.get() );
         BlockRendererUtils.registerBlock(event, Reference.ItemColor.APPENZELLER_CHEESE, GrowthcraftMilkBlocks.APPENZELLER_CHEESE_CURDS.get() );
         BlockRendererUtils.registerBlock(event, Reference.ItemColor.ASIAGO_CHEESE, GrowthcraftMilkBlocks.ASIAGO_CHEESE.get() );

--- a/src/main/java/growthcraft/milk/init/client/GrowthcraftMilkItemRenderers.java
+++ b/src/main/java/growthcraft/milk/init/client/GrowthcraftMilkItemRenderers.java
@@ -6,7 +6,7 @@ import growthcraft.milk.init.GrowthcraftMilkFluids;
 import growthcraft.milk.init.GrowthcraftMilkItems;
 import growthcraft.milk.shared.Reference;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.client.event.RegisterColorHandlersEvent;
+import net.minecraftforge.client.event.ColorHandlerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -14,7 +14,7 @@ import net.minecraftforge.fml.common.Mod;
 public class GrowthcraftMilkItemRenderers {
 
     @SubscribeEvent
-    public static void registerItemRenders(RegisterColorHandlersEvent.Item event) {
+    public static void registerItemRenders(ColorHandlerEvent.Item event) {
         ItemRendererUtils.registerItem(event, Reference.FluidColor.BUTTER_MILK.toItemColor(), GrowthcraftMilkFluids.BUTTER_MILK.bucket.get());
         ItemRendererUtils.registerItem(event, Reference.FluidColor.CHEESE_BASE.toItemColor(), GrowthcraftMilkFluids.CHEESE_BASE.bucket.get());
         ItemRendererUtils.registerItem(event, Reference.FluidColor.CONDENSED_MILK.toItemColor(), GrowthcraftMilkFluids.CONDENSED_MILK.bucket.get());

--- a/src/main/java/growthcraft/milk/item/MilkingBucketItem.java
+++ b/src/main/java/growthcraft/milk/item/MilkingBucketItem.java
@@ -49,13 +49,13 @@ public class MilkingBucketItem extends Item implements DispensibleContainerItem 
     public MilkingBucketItem(Fluid fluid) {
         super(getInitProperties());
         this.content = fluid;
-        this.fluidSupplier = net.minecraftforge.registries.ForgeRegistries.FLUIDS.getDelegateOrThrow(fluid);
+        this.fluidSupplier = this.content.delegate;
     }
 
     public MilkingBucketItem(Fluid fluid, Item.Properties properties) {
         super(properties);
         this.content = fluid;
-        this.fluidSupplier = net.minecraftforge.registries.ForgeRegistries.FLUIDS.getDelegateOrThrow(fluid);
+        this.fluidSupplier = this.content.delegate;
     }
 
     public MilkingBucketItem(Supplier<? extends Fluid> fluidSupplier, Properties properties) {
@@ -190,7 +190,7 @@ public class MilkingBucketItem extends Item implements DispensibleContainerItem 
     }
 
     protected void playEmptySound(@javax.annotation.Nullable Player p_40696_, LevelAccessor p_40697_, BlockPos p_40698_) {
-        SoundEvent soundevent = this.content.getFluidType().getSound(p_40696_, p_40697_, p_40698_, net.minecraftforge.common.SoundActions.BUCKET_EMPTY);
+        SoundEvent soundevent = this.content.getAttributes().getEmptySound(p_40697_, p_40698_);
         if(soundevent == null) soundevent = this.content.is(FluidTags.LAVA) ? SoundEvents.BUCKET_EMPTY_LAVA : SoundEvents.BUCKET_EMPTY;
         p_40697_.playSound(p_40696_, p_40698_, soundevent, SoundSource.BLOCKS, 1.0F, 1.0F);
         p_40697_.gameEvent(p_40696_, GameEvent.FLUID_PLACE, p_40698_);

--- a/src/main/java/growthcraft/milk/lib/networking/GrowthcraftMilkMessages.java
+++ b/src/main/java/growthcraft/milk/lib/networking/GrowthcraftMilkMessages.java
@@ -33,19 +33,19 @@ public class GrowthcraftMilkMessages {
         net.messageBuilder(MixingVatFluidSyncPacket.class, id(), NetworkDirection.PLAY_TO_CLIENT)
                 .decoder(MixingVatFluidSyncPacket::new)
                 .encoder(MixingVatFluidSyncPacket::toBytes)
-                .consumerMainThread(MixingVatFluidSyncPacket::handle)
+                .consumer(MixingVatFluidSyncPacket::handle)
                 .add();
 
         net.messageBuilder(PancheonFluidSyncPacket.class, id(), NetworkDirection.PLAY_TO_CLIENT)
                 .decoder(PancheonFluidSyncPacket::new)
                 .encoder(PancheonFluidSyncPacket::toBytes)
-                .consumerMainThread(PancheonFluidSyncPacket::handle)
+                .consumer(PancheonFluidSyncPacket::handle)
                 .add();
 
         net.messageBuilder(ChurnFluidTankSyncPacket.class, id(), NetworkDirection.PLAY_TO_CLIENT)
                 .decoder(ChurnFluidTankSyncPacket::new)
                 .encoder(ChurnFluidTankSyncPacket::toBytes)
-                .consumerMainThread(ChurnFluidTankSyncPacket::handle)
+                .consumer(ChurnFluidTankSyncPacket::handle)
                 .add();
     }
 

--- a/src/main/java/growthcraft/milk/recipe/CheesePressRecipe.java
+++ b/src/main/java/growthcraft/milk/recipe/CheesePressRecipe.java
@@ -2,6 +2,7 @@ package growthcraft.milk.recipe;
 
 import com.google.gson.JsonObject;
 import growthcraft.milk.GrowthcraftMilk;
+import growthcraft.milk.recipe.MixingVatItemRecipe.Serializer;
 import growthcraft.milk.shared.Reference;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.FriendlyByteBuf;
@@ -48,7 +49,7 @@ public class CheesePressRecipe implements Recipe<SimpleContainer> {
     }
 
     @Override
-    public ItemStack assemble(SimpleContainer container, RegistryAccess registryAccess) {
+    public ItemStack assemble(SimpleContainer container) {
         return this.outputItemStack;
     }
 
@@ -58,7 +59,7 @@ public class CheesePressRecipe implements Recipe<SimpleContainer> {
     }
 
     @Override
-    public ItemStack getResultItem(RegistryAccess registryAccess) {
+    public ItemStack getResultItem() {
         return this.getResultItemStack();
     }
 
@@ -106,6 +107,7 @@ public class CheesePressRecipe implements Recipe<SimpleContainer> {
         public static final ResourceLocation ID = new ResourceLocation(
                 Reference.MODID,
                 Reference.UnlocalizedName.CHEESE_PRESS_RECIPE);
+        private ResourceLocation name;
 
         @Override
         public @NotNull CheesePressRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
@@ -142,6 +144,27 @@ public class CheesePressRecipe implements Recipe<SimpleContainer> {
             buffer.writeVarInt(recipe.getProcessingTime());
 
         }
+        
+		@Override
+		public RecipeSerializer<?> setRegistryName(ResourceLocation name) {
+			this.name = name;
+			return this;
+		}
+
+		@Override
+		public ResourceLocation getRegistryName() {
+			return name;
+		}
+
+		@Override
+		public Class<RecipeSerializer<?>> getRegistryType() {
+			// TODO Auto-generated method stub
+			return Serializer.<RecipeSerializer<?>>castClass(RecipeSerializer.class);
+		}
+
+		private static <G> Class<G> castClass(Class<?> cls) {
+	        return (Class<G>) cls;
+	    }
 
     }
 

--- a/src/main/java/growthcraft/milk/recipe/ChurnRecipe.java
+++ b/src/main/java/growthcraft/milk/recipe/ChurnRecipe.java
@@ -3,6 +3,7 @@ package growthcraft.milk.recipe;
 import com.google.gson.JsonObject;
 import growthcraft.lib.utils.CraftingUtils;
 import growthcraft.milk.GrowthcraftMilk;
+import growthcraft.milk.recipe.MixingVatItemRecipe.Serializer;
 import growthcraft.milk.shared.Reference;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.FriendlyByteBuf;
@@ -38,7 +39,7 @@ public class ChurnRecipe implements Recipe<SimpleContainer> {
     }
 
     @Override
-    public ItemStack assemble(SimpleContainer simpleContainer, RegistryAccess registryAccess) {
+    public ItemStack assemble(SimpleContainer simpleContainer) {
         return this.resultItemStack;
     }
 
@@ -74,7 +75,7 @@ public class ChurnRecipe implements Recipe<SimpleContainer> {
     }
 
     @Override
-    public ItemStack getResultItem(RegistryAccess registryAccess) {
+    public ItemStack getResultItem() {
         return this.resultItemStack;
     }
 
@@ -111,6 +112,7 @@ public class ChurnRecipe implements Recipe<SimpleContainer> {
         public static final ResourceLocation ID = new ResourceLocation(
                 Reference.MODID,
                 Reference.UnlocalizedName.CHURN_RECIPE);
+        private ResourceLocation name;
 
         @Override
         public @NotNull ChurnRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
@@ -151,6 +153,27 @@ public class ChurnRecipe implements Recipe<SimpleContainer> {
             buffer.writeVarInt(recipe.getByProductChance());
 
         }
+        
+		@Override
+		public RecipeSerializer<?> setRegistryName(ResourceLocation name) {
+			this.name = name;
+			return this;
+		}
+
+		@Override
+		public ResourceLocation getRegistryName() {
+			return name;
+		}
+
+		@Override
+		public Class<RecipeSerializer<?>> getRegistryType() {
+			// TODO Auto-generated method stub
+			return Serializer.<RecipeSerializer<?>>castClass(RecipeSerializer.class);
+		}
+
+		private static <G> Class<G> castClass(Class<?> cls) {
+	        return (Class<G>) cls;
+	    }
 
     }
 }

--- a/src/main/java/growthcraft/milk/recipe/MixingVatFluidRecipe.java
+++ b/src/main/java/growthcraft/milk/recipe/MixingVatFluidRecipe.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import growthcraft.lib.utils.CraftingUtils;
 import growthcraft.lib.utils.RecipeUtils;
 import growthcraft.milk.GrowthcraftMilk;
+import growthcraft.milk.recipe.MixingVatItemRecipe.Serializer;
 import growthcraft.milk.shared.Reference;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.FriendlyByteBuf;
@@ -103,12 +104,12 @@ public class MixingVatFluidRecipe implements Recipe<SimpleContainer> {
     }
 
     @Override
-    public ItemStack assemble(SimpleContainer container, RegistryAccess registryAccess) {
+    public ItemStack assemble(SimpleContainer container) {
         return this.outputFluidStack.getFluid().getBucket().getDefaultInstance();
     }
 
     @Override
-    public ItemStack getResultItem(RegistryAccess registryAccess) {
+    public ItemStack getResultItem() {
         return this.outputFluidStack.getFluid().getBucket().getDefaultInstance();
     }
 
@@ -177,6 +178,7 @@ public class MixingVatFluidRecipe implements Recipe<SimpleContainer> {
         public static final ResourceLocation ID = new ResourceLocation(
                 Reference.MODID,
                 Reference.UnlocalizedName.MIXING_VAT_FLUID_RECIPE);
+        private ResourceLocation name;
 
         private static final int maxIngredients = 3;
 
@@ -262,5 +264,25 @@ public class MixingVatFluidRecipe implements Recipe<SimpleContainer> {
 
         }
 
+		@Override
+		public RecipeSerializer<?> setRegistryName(ResourceLocation name) {
+			this.name = name;
+			return this;
+		}
+
+		@Override
+		public ResourceLocation getRegistryName() {
+			return name;
+		}
+
+		@Override
+		public Class<RecipeSerializer<?>> getRegistryType() {
+			// TODO Auto-generated method stub
+			return Serializer.<RecipeSerializer<?>>castClass(RecipeSerializer.class);
+		}
+
+		private static <G> Class<G> castClass(Class<?> cls) {
+	        return (Class<G>) cls;
+	    }
     }
 }

--- a/src/main/java/growthcraft/milk/recipe/MixingVatItemRecipe.java
+++ b/src/main/java/growthcraft/milk/recipe/MixingVatItemRecipe.java
@@ -2,6 +2,8 @@ package growthcraft.milk.recipe;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+
+import growthcraft.cellar.recipe.BrewKettleRecipe.Serializer;
 import growthcraft.lib.utils.CraftingUtils;
 import growthcraft.lib.utils.RecipeUtils;
 import growthcraft.milk.GrowthcraftMilk;
@@ -107,12 +109,12 @@ public class MixingVatItemRecipe implements Recipe<SimpleContainer> {
     }
 
 
-    public ItemStack assemble(SimpleContainer container, RegistryAccess registryAccess) {
+    public ItemStack assemble(SimpleContainer container) {
         return resultItemStack;
     }
 
 
-    public ItemStack getResultItem(RegistryAccess registryAccess) {
+    public ItemStack getResultItem() {
         return resultItemStack;
     }
 
@@ -157,6 +159,7 @@ public class MixingVatItemRecipe implements Recipe<SimpleContainer> {
         public static final ResourceLocation ID = new ResourceLocation(
                 Reference.MODID,
                 Reference.UnlocalizedName.MIXING_VAT_RECIPE);
+        private ResourceLocation name;
 
         private static final int maxIngredients = 3;
 
@@ -241,6 +244,27 @@ public class MixingVatItemRecipe implements Recipe<SimpleContainer> {
             buffer.writeItemStack(recipe.getResultActivationTool(), false);
 
         }
+        
+		@Override
+		public RecipeSerializer<?> setRegistryName(ResourceLocation name) {
+			this.name = name;
+			return this;
+		}
+
+		@Override
+		public ResourceLocation getRegistryName() {
+			return name;
+		}
+
+		@Override
+		public Class<RecipeSerializer<?>> getRegistryType() {
+			// TODO Auto-generated method stub
+			return Serializer.<RecipeSerializer<?>>castClass(RecipeSerializer.class);
+		}
+
+		private static <G> Class<G> castClass(Class<?> cls) {
+	        return (Class<G>) cls;
+	    }
 
     }
 }

--- a/src/main/java/growthcraft/milk/recipe/PancheonRecipe.java
+++ b/src/main/java/growthcraft/milk/recipe/PancheonRecipe.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import growthcraft.lib.utils.CraftingUtils;
 import growthcraft.milk.GrowthcraftMilk;
+import growthcraft.milk.recipe.MixingVatItemRecipe.Serializer;
 import growthcraft.milk.shared.Reference;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.FriendlyByteBuf;
@@ -53,7 +54,7 @@ public class PancheonRecipe implements Recipe<SimpleContainer> {
     }
 
     @Override
-    public ItemStack assemble(SimpleContainer simpleContainer, RegistryAccess registryAccess) {
+    public ItemStack assemble(SimpleContainer simpleContainer) {
         return this.outputFluidStack1.getFluid().getBucket().getDefaultInstance();
     }
 
@@ -63,7 +64,7 @@ public class PancheonRecipe implements Recipe<SimpleContainer> {
     }
 
     @Override
-    public ItemStack getResultItem(RegistryAccess registryAccess) {
+    public ItemStack getResultItem() {
         return this.getFluidStack(OUTPUT_0).getFluid().getBucket().getDefaultInstance();
     }
 
@@ -110,6 +111,7 @@ public class PancheonRecipe implements Recipe<SimpleContainer> {
         public static final ResourceLocation ID = new ResourceLocation(
                 Reference.MODID,
                 Reference.UnlocalizedName.PANCHEON_RECIPE);
+        private ResourceLocation name;
 
         @Override
         public @NotNull PancheonRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
@@ -147,6 +149,27 @@ public class PancheonRecipe implements Recipe<SimpleContainer> {
             buffer.writeFluidStack(recipe.getFluidStack(OUTPUT_1));
             buffer.writeVarInt(recipe.getRecipeProcessingTime());
         }
+        
+		@Override
+		public RecipeSerializer<?> setRegistryName(ResourceLocation name) {
+			this.name = name;
+			return this;
+		}
+
+		@Override
+		public ResourceLocation getRegistryName() {
+			return name;
+		}
+
+		@Override
+		public Class<RecipeSerializer<?>> getRegistryType() {
+			// TODO Auto-generated method stub
+			return Serializer.<RecipeSerializer<?>>castClass(RecipeSerializer.class);
+		}
+
+		private static <G> Class<G> castClass(Class<?> cls) {
+	        return (Class<G>) cls;
+	    }
 
     }
 

--- a/src/main/java/growthcraft/rice/GrowthcraftRice.java
+++ b/src/main/java/growthcraft/rice/GrowthcraftRice.java
@@ -1,15 +1,15 @@
 package growthcraft.rice;
 
-import growthcraft.core.init.GrowthcraftCreativeModeTabs;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import growthcraft.rice.init.GrowthcraftRiceBlocks;
 import growthcraft.rice.init.GrowthcraftRiceFluids;
 import growthcraft.rice.init.GrowthcraftRiceItems;
 import growthcraft.rice.init.client.GrowthcraftRiceBlockRenderers;
 import growthcraft.rice.init.config.GrowthcraftRiceConfig;
 import growthcraft.rice.shared.Reference;
-import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.CreativeModeTabEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -17,8 +17,6 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 @Mod(Reference.MODID)
 @Mod.EventBusSubscriber(modid = Reference.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
@@ -29,7 +27,7 @@ public class GrowthcraftRice {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         modEventBus.addListener(this::setup);
         modEventBus.addListener(this::clientSetupEvent);
-        modEventBus.addListener(this::buildCreativeTabContents);
+        //modEventBus.addListener(this::buildCreativeTabContents);
 
         // Config
         GrowthcraftRiceConfig.loadConfig();
@@ -37,8 +35,8 @@ public class GrowthcraftRice {
         // Blocks, Items, Fluids, Block Entities, Containers
         GrowthcraftRiceBlocks.BLOCKS.register(modEventBus);
         GrowthcraftRiceItems.ITEMS.register(modEventBus);
-        GrowthcraftRiceFluids.FLUID_TYPES.register(modEventBus);
-        GrowthcraftRiceFluids.FLUIDS.register(modEventBus);
+        //GrowthcraftRiceFluids.FLUID_TYPES.register(modEventBus);
+        //GrowthcraftRiceFluids.FLUIDS.register(modEventBus);
 
         MinecraftForge.EVENT_BUS.register(this);
     }
@@ -51,15 +49,15 @@ public class GrowthcraftRice {
         // Do Nothing for now ...
     }
 
-    public void buildCreativeTabContents(CreativeModeTabEvent.BuildContents event) {
-        if (event.getTab() == GrowthcraftCreativeModeTabs.GROWTHCRAFT_CREATIVE_TAB) {
-            GrowthcraftRiceItems.ITEMS.getEntries().forEach(itemRegistryObject -> {
-                if (!GrowthcraftRiceItems.excludeItemRegistry(itemRegistryObject.getId())) {
-                    event.accept(new ItemStack(itemRegistryObject.get()));
-                }
-            });
-        }
-    }
+//    public void buildCreativeTabContents(CreativeModeTabEvent.BuildContents event) {
+//        if (event.getTab() == GrowthcraftCreativeModeTabs.GROWTHCRAFT_CREATIVE_TAB) {
+//            GrowthcraftRiceItems.ITEMS.getEntries().forEach(itemRegistryObject -> {
+//                if (!GrowthcraftRiceItems.excludeItemRegistry(itemRegistryObject.getId())) {
+//                    event.accept(new ItemStack(itemRegistryObject.get()));
+//                }
+//            });
+//        }
+//    }
 
     @SubscribeEvent
     public void onServerStarting(ServerStartingEvent event) {

--- a/src/main/java/growthcraft/rice/init/client/GrowthcraftRiceItemRenderers.java
+++ b/src/main/java/growthcraft/rice/init/client/GrowthcraftRiceItemRenderers.java
@@ -4,7 +4,7 @@ import growthcraft.lib.client.ItemRendererUtils;
 import growthcraft.rice.init.GrowthcraftRiceFluids;
 import growthcraft.rice.shared.Reference;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.client.event.RegisterColorHandlersEvent;
+import net.minecraftforge.client.event.ColorHandlerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -12,7 +12,7 @@ import net.minecraftforge.fml.common.Mod;
 public class GrowthcraftRiceItemRenderers {
 
     @SubscribeEvent
-    public static void registerItemRenders(RegisterColorHandlersEvent.Item event) {
+    public static void registerItemRenders(ColorHandlerEvent.Item event) {
         ItemRendererUtils.registerItem(event, Reference.FluidColor.RICE_WATER.toItemColor(), GrowthcraftRiceFluids.RICE_WATER.bucket.get());
         ItemRendererUtils.registerItem(event, Reference.FluidColor.RICE_WINE.toItemColor(), GrowthcraftRiceFluids.RICE_WINE.bucket.get());
         ItemRendererUtils.registerItem(event, Reference.FluidColor.SAKE.toItemColor(), GrowthcraftRiceFluids.SAKE.bucket.get());

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,7 +1,7 @@
 modLoader="javafml" #mandatory
-loaderVersion="[45,)"
+loaderVersion="[40,)"
 license = "GPL-3.0"
-issueTrackerURL = "https://github.com/GrowthcraftCE/Growthcraft-1.19/issues"
+issueTrackerURL = "https://github.com/GrowthcraftCE/Growthcraft-1.18/issues"
 
 [[mods]]
 modId = "growthcraft"
@@ -19,14 +19,14 @@ Growthcraft is a realistic and immersive Forge mod that adds various new element
 [[dependencies.growthcraft]] #optional
 modId = "forge"
 mandatory = true
-versionRange = "[45,)"
+versionRange = "[40,)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.growthcraft]]
 modId = "minecraft"
 mandatory = true
-versionRange = "[1.18.2,1.20)"
+versionRange = "[1.18.2,1.19)"
 ordering = "NONE"
 side = "BOTH"
 
@@ -106,7 +106,7 @@ description = '''
 [[dependencies.growthcraft_milk]]
 modId = "growthcraft"
 mandatory = true
-versionRange = "[8,)"
+versionRange = "[7,)"
 ordering = "AFTER"
 side = "BOTH"
 


### PR DESCRIPTION
This should correct most of the issues with 1.18 (renames that happend in 1.19 or changes like the CraftingTab)

Main issues that still exist:
Fluids
Registry Changes for Fluids and the use of BootstapContext
some sort of imcompatability with GC trappe): exporting both growthcraft.lib.utils 